### PR TITLE
fix: allow floats for model requirement values

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -11,20 +11,10 @@ on:
       - '.github/workflows/maintests.yml'
       - '.github/workflows/prtests.yml'
       - '.github/workflows/release.yml'
-      - '.pre-commit-config.yaml'
       - 'requirements.txt'
       - 'requirements.dev.txt'
       - 'requirements.docs.txt'
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: --all-files
-
   no_extra_fields:
     env:
       AIWORKER_CACHE_HOME: ${{ github.workspace }}/.cache

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -14,22 +14,10 @@ on:
       - '.github/workflows/maintests.yml'
       - '.github/workflows/prtests.yml'
       - '.github/workflows/release.yml'
-      - '.pre-commit-config.yaml'
       - 'requirements.txt'
       - 'requirements.dev.txt'
       - 'requirements.docs.txt'
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: --all-files
-
   no_extra_fields:
     env:
       AIWORKER_CACHE_HOME: ${{ github.workspace }}/.cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,15 +6,15 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
     -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.7
+    rev: v0.6.7
     hooks:
     -    id: ruff
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.10.0'
+    rev: 'v1.11.2'
     hooks:
     -   id: mypy
         additional_dependencies: [pydantic, types-requests, types-pytz, types-setuptools, types-urllib3, StrEnum]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,14 @@ repos:
     hooks:
     -   id: mypy
         additional_dependencies: [pydantic, types-requests, types-pytz, types-setuptools, types-urllib3, StrEnum]
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.7
+    rev: v0.6.8
     hooks:
     -    id: ruff
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/horde_model_reference/legacy/classes/raw_legacy_model_database_records.py
+++ b/horde_model_reference/legacy/classes/raw_legacy_model_database_records.py
@@ -59,7 +59,7 @@ class RawLegacy_StableDiffusion_ModelRecord(BaseModel):
     homepage: str | None = None
     nsfw: bool
     download_all: bool
-    requirements: dict[str, int | float | str | list[int] | list[str] | bool] | None = None
+    requirements: dict[str, int | float | str | list[int] | list[float] | list[str] | bool] | None = None
     config: Mapping[str, list[RawLegacy_FileRecord | RawLegacy_DownloadRecord]]
     available: bool | None = None
     features_not_supported: list[FEATURE_SUPPORTED] | None = None

--- a/horde_model_reference/legacy/classes/raw_legacy_model_database_records.py
+++ b/horde_model_reference/legacy/classes/raw_legacy_model_database_records.py
@@ -59,7 +59,7 @@ class RawLegacy_StableDiffusion_ModelRecord(BaseModel):
     homepage: str | None = None
     nsfw: bool
     download_all: bool
-    requirements: dict[str, int | str | list[int] | list[str] | bool] | None = None
+    requirements: dict[str, int | float | str | list[int] | list[str] | bool] | None = None
     config: Mapping[str, list[RawLegacy_FileRecord | RawLegacy_DownloadRecord]]
     available: bool | None = None
     features_not_supported: list[FEATURE_SUPPORTED] | None = None

--- a/horde_model_reference/legacy/classes/staging_model_database_records.py
+++ b/horde_model_reference/legacy/classes/staging_model_database_records.py
@@ -96,7 +96,7 @@ class Legacy_StableDiffusion_ModelRecord(StagingLegacy_Generic_ModelRecord):
     homepage: str | None = None
     size_on_disk_bytes: int | None = None
     optimization: str | None = None
-    requirements: dict[str, int | str | list[int] | list[str] | bool] | None = None
+    requirements: dict[str, int | float | str | list[int] | list[float] | list[str] | bool] | None = None
 
 
 class Legacy_Generic_ModelReference(BaseModel):

--- a/horde_model_reference/model_reference_records.py
+++ b/horde_model_reference/model_reference_records.py
@@ -90,7 +90,7 @@ class StableDiffusion_ModelRecord(Generic_ModelRecord):
     style: MODEL_STYLE | str | None = None
     """The style of the model."""
 
-    requirements: dict[str, int | str | list[int] | list[str] | bool] | None = None
+    requirements: dict[str, int | float | str | list[int] | list[float] | list[str] | bool] | None = None
 
     size_on_disk_bytes: int | None = None
 

--- a/legacy_stable_diffusion.schema.json
+++ b/legacy_stable_diffusion.schema.json
@@ -243,11 +243,20 @@
                                         "type": "integer"
                                     },
                                     {
+                                        "type": "number"
+                                    },
+                                    {
                                         "type": "string"
                                     },
                                     {
                                         "items": {
                                             "type": "integer"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "items": {
+                                            "type": "number"
                                         },
                                         "type": "array"
                                     },

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,9 +1,9 @@
-pytest==8.2.1
-mypy==1.10.0
-black==24.4.2
-ruff==0.4.7
-tox~=4.15.0
-pre-commit~=3.7.1
+pytest==8.3.3
+mypy==1.11.2
+black==24.8.0
+ruff==0.6.8
+tox~=4.20.0
+pre-commit~=3.8.0
 build>=0.10.0
 coverage>=7.2.7
 

--- a/stable_diffusion.schema.json
+++ b/stable_diffusion.schema.json
@@ -285,11 +285,20 @@
                                         "type": "integer"
                                     },
                                     {
+                                        "type": "number"
+                                    },
+                                    {
                                         "type": "string"
                                     },
                                     {
                                         "items": {
                                             "type": "integer"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "items": {
+                                            "type": "number"
                                         },
                                         "type": "array"
                                     },


### PR DESCRIPTION
- As noted in #147, float values for payloads should be considered valid, as in the case with CFG scale which can have a value after the decimal (e.g., `3.5`).
- Additionally, lint/formatting/testing dependencies and pre-commit hooks have deep updated and https://pre-commit.ci/ is now being used in preference over the previous github action which had a similar purpose.