### PR TITLE
feat: group alias/family/schema stores + parser

### DIFF
--- a/src/horde_model_reference/analytics/text_model_grouping.py
+++ b/src/horde_model_reference/analytics/text_model_grouping.py
@@ -2,6 +2,10 @@
 
 Provides functionality to group text generation models by base name (stripping
 quantization information) and aggregate metrics across grouped variants.
+
+When a :class:`~horde_model_reference.group_aliases.GroupAliasStore` is
+provided, alias resolution is applied after base-name extraction so that
+explicitly aliased model families are collapsed into a single group.
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ from horde_model_reference.analytics.deletion_risk_analysis import (
     UsageTrend,
 )
 from horde_model_reference.analytics.text_model_parser import get_base_model_name
+from horde_model_reference.group_aliases import GroupAliasStore
 from horde_model_reference.meta_consts import MODEL_REFERENCE_CATEGORY
 
 
@@ -89,14 +94,22 @@ def merge_usage_trends(trends: list[UsageTrend], weights: list[int]) -> UsageTre
     )
 
 
-def group_risk_models(models: list[ModelDeletionRiskInfo]) -> list[ModelDeletionRiskInfo]:
+def group_risk_models(
+    models: list[ModelDeletionRiskInfo],
+    *,
+    alias_store: GroupAliasStore | None = None,
+) -> list[ModelDeletionRiskInfo]:
     """Group text model variants by base name and aggregate metrics.
 
     Combines multiple quantization variants (Q4_K_M, Q5_0, etc.) into a single
     model entry with aggregated metrics.
 
+    When *alias_store* is provided, the alias-resolved canonical name is used
+    as the group key so that explicitly aliased families are merged.
+
     Args:
         models: List of ModelDeletionRiskInfo objects to group.
+        alias_store: Optional alias store for resolving group names.
 
     Returns:
         List of grouped ModelDeletionRiskInfo objects with aggregated metrics.
@@ -110,6 +123,8 @@ def group_risk_models(models: list[ModelDeletionRiskInfo]) -> list[ModelDeletion
     grouped: dict[str, list[ModelDeletionRiskInfo]] = {}
     for model in models:
         base_name = get_base_model_name(model.name)
+        if alias_store is not None:
+            base_name = alias_store.resolve(base_name)
         if base_name not in grouped:
             grouped[base_name] = []
         grouped[base_name].append(model)
@@ -240,6 +255,8 @@ def recalculate_risk_summary(
 
 def apply_text_model_grouping_to_risk_response(
     risk_response: CategoryDeletionRiskResponse,
+    *,
+    alias_store: GroupAliasStore | None = None,
 ) -> CategoryDeletionRiskResponse:
     """Apply text model grouping to deletion risk response.
 
@@ -247,6 +264,7 @@ def apply_text_model_grouping_to_risk_response(
 
     Args:
         risk_response: Original CategoryDeletionRiskResponse.
+        alias_store: Optional alias store for resolving group names.
 
     Returns:
         New CategoryDeletionRiskResponse with grouped models and updated summary.
@@ -258,7 +276,7 @@ def apply_text_model_grouping_to_risk_response(
         logger.debug(f"Skipping grouping for non-text category: {risk_response.category}")
         return risk_response
 
-    grouped_models = group_risk_models(risk_response.models)
+    grouped_models = group_risk_models(risk_response.models, alias_store=alias_store)
     new_summary = recalculate_risk_summary(grouped_models, risk_response.category_total_month_usage)
 
     return CategoryDeletionRiskResponse(

--- a/src/horde_model_reference/analytics/text_model_parser.py
+++ b/src/horde_model_reference/analytics/text_model_parser.py
@@ -3,15 +3,57 @@
 Provides functions to parse text generation model names into structured components
 like base name, size, variant, and quantization. Useful for grouping model variants
 (e.g., different quant versions of the same base model).
+
+The parser recognises five *primary* parts (base, size, variant, version, quant) and
+an open-ended list of *extra* parts — name segments that do not fit any primary
+category (date suffixes, descriptive variant words, sub-model identifiers, etc.).
 """
 
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from enum import auto
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
 from loguru import logger
+from strenum import StrEnum
+
+if TYPE_CHECKING:
+    from horde_model_reference.group_aliases import GroupAliasStore
+
+
+class ExtraPartType(StrEnum):
+    """Classification of a name segment that does not fit any primary part category."""
+
+    DATE = auto()
+    """Calendar-style suffix such as ``08-2024`` or ``2024-03``."""
+
+    DESCRIPTOR = auto()
+    """A descriptive word that is not in the standard variant list (e.g., ``Transgression``, ``Unslop``)."""
+
+    LEADING_VERSION = auto()
+    """A dotted version string that appears *before* the base name (e.g., ``4.2.0-``)."""
+
+    UNKNOWN = auto()
+    """Could not be automatically classified."""
+
+
+@dataclass(frozen=True)
+class ExtraNamePart:
+    """A name segment that was not classified as a primary part.
+
+    Attributes:
+        value: The raw text of the segment.
+        position: Zero-based ordinal position within the separator-split name.
+        inferred_type: Best-guess classification, or ``UNKNOWN``.
+
+    """
+
+    value: str
+    position: int
+    inferred_type: ExtraPartType = ExtraPartType.UNKNOWN
 
 
 @dataclass
@@ -26,6 +68,7 @@ class ParsedTextModelName:
         quant: Quantization type if detected (e.g., "Q4", "Q8", "GGUF").
         version: Model version if detected (e.g., "v0.1", "v2.1").
         normalized_name: A normalized version of the name for comparison.
+        extras: Name segments that did not match any primary part category.
 
     """
 
@@ -36,6 +79,7 @@ class ParsedTextModelName:
     quant: str | None = None
     version: str | None = None
     normalized_name: str | None = None
+    extras: list[ExtraNamePart] = field(default_factory=list)
 
 
 # Common text model size patterns
@@ -55,6 +99,7 @@ VERSION_PATTERNS = [
 # Common variant indicators
 VARIANT_PATTERNS = [
     r"\b(Instruct|Chat|Code|Base|Uncensored|Finetune|FT)\b",
+    r"\b(Thinking|Reasoning)\b",
     r"\b(turbo|preview|latest)\b",
 ]
 
@@ -67,6 +112,16 @@ QUANT_PATTERNS = [
     r"\b(fp16|fp32|int8|int4)\b",
 ]
 
+# Date-like suffixes that model authors append (e.g., "08-2024", "03-2025", "2024-03")
+DATE_PATTERNS = [
+    r"(?<![a-zA-Z0-9])(\d{2}-\d{4})(?![a-zA-Z0-9])",  # MM-YYYY (e.g., 08-2024)
+    r"(?<![a-zA-Z0-9])(\d{4}-\d{2})(?![a-zA-Z0-9])",  # YYYY-MM (e.g., 2024-08)
+    r"(?<![a-zA-Z0-9])(\d{4})(?![a-zA-Z0-9])",  # Standalone 4-digit date code (YYMM/MMDD: 2407, 0414)
+]
+
+# Dotted version string that appears *before* the base name (e.g., "4.2.0-Broken-Tutu")
+LEADING_VERSION_PATTERN = r"^(\d+\.\d+(?:\.\d+)?)[_\-]"
+
 # Separators to normalize
 SEPARATORS = ["-", "_", " ", "."]
 
@@ -75,21 +130,29 @@ SEPARATORS = ["-", "_", " ", "."]
 def parse_text_model_name(model_name: str) -> ParsedTextModelName:
     """Parse a text model name into structured components.
 
-    Attempts to extract base name, size, variant, and quantization information
-    from a model name using regex patterns.
+    Attempts to extract base name, size, variant, quantization, version,
+    and *extra* segments from a model name using regex patterns.
+
+    Extraction order: leading version → size → version → quant → variant → date.
+    Segments that remain after all primary extractions are classified as extras.
 
     Args:
         model_name: The full model name to parse.
 
     Returns:
-        ParsedTextModelName with extracted components.
+        ParsedTextModelName with extracted components and extras.
 
     Example:
         >>> parsed = parse_text_model_name("Llama-3-8B-Instruct-Q4_K_M")
-        >>> print(parsed.base_name)  # "Llama-3"
-        >>> print(parsed.size)  # "8B"
-        >>> print(parsed.variant)  # "Instruct"
-        >>> print(parsed.quant)  # "Q4_K_M"
+        >>> parsed.base_name
+        'Llama-3'
+        >>> parsed.size
+        '8B'
+        >>> parsed = parse_text_model_name("c4ai-command-r-08-2024")
+        >>> parsed.base_name
+        'c4ai-command-r'
+        >>> parsed.extras[0].inferred_type
+        <ExtraPartType.DATE: 'date'>
 
     """
     logger.trace(f"Parsing text model name: {model_name}")
@@ -99,8 +162,23 @@ def parse_text_model_name(model_name: str) -> ParsedTextModelName:
     variant = None
     quant = None
     version = None
+    extras: list[ExtraNamePart] = []
 
-    # Extract size
+    # --- Extract leading dotted-version (e.g., "4.2.0-Broken-Tutu") ---
+    leading_match = re.match(LEADING_VERSION_PATTERN, name_parts)
+    if leading_match:
+        leading_ver = leading_match.group(1)
+        extras.append(
+            ExtraNamePart(
+                value=leading_ver,
+                position=0,
+                inferred_type=ExtraPartType.LEADING_VERSION,
+            ),
+        )
+        name_parts = name_parts[leading_match.end() :]
+        logger.trace(f"Extracted leading version extra: {leading_ver}")
+
+    # --- Extract size ---
     for pattern in SIZE_PATTERNS:
         match = re.search(pattern, name_parts, re.IGNORECASE)
         if match:
@@ -109,7 +187,7 @@ def parse_text_model_name(model_name: str) -> ParsedTextModelName:
             logger.trace(f"Extracted size: {size}")
             break
 
-    # Extract version (after size so v-prefixed versions aren't confused with sizes)
+    # --- Extract version (after size so v-prefixed versions aren't confused with sizes) ---
     for pattern in VERSION_PATTERNS:
         match = re.search(pattern, name_parts, re.IGNORECASE)
         if match:
@@ -118,7 +196,7 @@ def parse_text_model_name(model_name: str) -> ParsedTextModelName:
             logger.trace(f"Extracted version: {version}")
             break
 
-    # Extract quantization
+    # --- Extract quantization ---
     for pattern in QUANT_PATTERNS:
         match = re.search(pattern, name_parts, re.IGNORECASE)
         if match:
@@ -127,13 +205,29 @@ def parse_text_model_name(model_name: str) -> ParsedTextModelName:
             logger.trace(f"Extracted quant: {quant}")
             break
 
-    # Extract variant
+    # --- Extract variant ---
     for pattern in VARIANT_PATTERNS:
         match = re.search(pattern, name_parts, re.IGNORECASE)
         if match:
             variant = match.group(1)
             name_parts = name_parts[: match.start()] + name_parts[match.end() :]
             logger.trace(f"Extracted variant: {variant}")
+            break
+
+    # --- Extract date suffixes as extras ---
+    for pattern in DATE_PATTERNS:
+        match = re.search(pattern, name_parts)
+        if match:
+            date_value = match.group(1)
+            extras.append(
+                ExtraNamePart(
+                    value=date_value,
+                    position=_count_separators_before(model_name, match.start()),
+                    inferred_type=ExtraPartType.DATE,
+                ),
+            )
+            name_parts = name_parts[: match.start()] + name_parts[match.end() :]
+            logger.trace(f"Extracted date extra: {date_value}")
             break
 
     # Clean up base name — collapse repeated separators and strip edges
@@ -160,7 +254,18 @@ def parse_text_model_name(model_name: str) -> ParsedTextModelName:
         quant=quant,
         version=version,
         normalized_name=normalized,
+        extras=extras,
     )
+
+
+def _count_separators_before(text: str, position: int) -> int:
+    """Count how many separator-delimited segments occur before *position* in *text*."""
+    prefix = text[:position]
+    count = 0
+    for char in prefix:
+        if char in "-_. ":
+            count += 1
+    return count
 
 
 @lru_cache(maxsize=2048)
@@ -246,13 +351,18 @@ class TextModelGroup:
 
 def group_text_models_by_base(
     model_names: list[str],
+    *,
+    alias_store: GroupAliasStore | None = None,
 ) -> dict[str, TextModelGroup]:
     """Group text model names by their base model.
 
     Groups variants of the same model together based on extracted base names.
+    When *alias_store* is provided, alias-resolved canonical names are used
+    as group keys.
 
     Args:
         model_names: List of model names to group.
+        alias_store: Optional alias store for resolving group names.
 
     Returns:
         Dictionary mapping base names to lists of full model names.
@@ -276,6 +386,8 @@ def group_text_models_by_base(
 
     for model_name in model_names:
         base_name = get_base_model_name(model_name)
+        if alias_store is not None:
+            base_name = alias_store.resolve(base_name)
 
         if base_name not in grouped:
             grouped[base_name] = []
@@ -361,6 +473,10 @@ class NameFormatSchema:
     """Describes the naming convention inferred from a group of models.
 
     Used by compose_name to produce names consistent with existing group members.
+
+    ``extra_parts`` lists labels for name segments that do not fit any primary
+    category (e.g., ``["date"]``).  The labels are free-form strings that help
+    admins understand what the segment represents.
     """
 
     separator: str = "-"
@@ -368,6 +484,7 @@ class NameFormatSchema:
     author_included: bool = False
     common_author: str | None = None
     template: str = "{base}-{size}"
+    extra_parts: list[str] = field(default_factory=list)
 
 
 def _detect_separator(names: list[str]) -> str:
@@ -387,7 +504,11 @@ def _detect_separator(names: list[str]) -> str:
 
 
 def _detect_part_order(original: str, parsed: ParsedTextModelName) -> list[str]:
-    """Detect the order of parts in a model name by their position in the original string."""
+    """Detect the order of parts in a model name by their position in the original string.
+
+    Includes extra-part labels (prefixed with ``extra:``) so that the inferred
+    template reflects the full name structure.
+    """
     parts: dict[str, str] = {}
     if parsed.base_name:
         parts["base"] = parsed.base_name
@@ -399,6 +520,9 @@ def _detect_part_order(original: str, parsed: ParsedTextModelName) -> list[str]:
         parts["version"] = parsed.version
     if parsed.quant:
         parts["quant"] = parsed.quant
+    for extra in parsed.extras:
+        label = f"extra:{extra.inferred_type.value}"
+        parts[label] = extra.value
 
     positions: dict[str, int] = {}
     original_lower = original.lower()
@@ -447,9 +571,19 @@ def infer_name_format(member_names: list[str]) -> NameFormatSchema:
     parsed_members = [parse_text_model_name(n) for n in names_without_author]
     richest = max(
         zip(names_without_author, parsed_members, strict=False),
-        key=lambda pair: sum(1 for v in [pair[1].size, pair[1].variant, pair[1].version, pair[1].quant] if v),
+        key=lambda pair: (
+            sum(1 for v in [pair[1].size, pair[1].variant, pair[1].version, pair[1].quant] if v) + len(pair[1].extras)
+        ),
     )
     part_order = _detect_part_order(richest[0], richest[1])
+
+    # Collect unique extra-part labels across all members
+    seen_extra_labels: list[str] = []
+    for pm in parsed_members:
+        for extra in pm.extras:
+            label = extra.inferred_type.value
+            if label not in seen_extra_labels:
+                seen_extra_labels.append(label)
 
     # Build human-readable template
     template_parts: list[str] = []
@@ -468,6 +602,7 @@ def infer_name_format(member_names: list[str]) -> NameFormatSchema:
         author_included=author_included,
         common_author=common_author,
         template=template,
+        extra_parts=seen_extra_labels,
     )
 
 

--- a/src/horde_model_reference/data/generation_params.json
+++ b/src/horde_model_reference/data/generation_params.json
@@ -16,13 +16,9 @@
   "top_k": 100,
   "top_p": 1,
   "typical": 1,
-  "sampler_order": [
-    0
-  ],
+  "sampler_order": [0],
   "use_default_badwordsids": true,
-  "stop_sequence": [
-    "string"
-  ],
+  "stop_sequence": ["string"],
   "min_p": 0,
   "smoothing_factor": 0,
   "dynatemp_range": 0,

--- a/src/horde_model_reference/group_aliases.py
+++ b/src/horde_model_reference/group_aliases.py
@@ -1,0 +1,207 @@
+"""File-backed persistence for text model group aliases.
+
+Provides a canonical-name → alias mapping so that distinct parser base names
+(e.g., ``c4ai-command-r``, ``c4ai-command-r-plus``, ``c4ai-command-a``) can
+be collapsed into a single group during grouping operations.
+
+This is the correct mechanism for model families whose names differ in ways
+the parser cannot resolve heuristically — the alias is always an explicit
+admin decision.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import RLock
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from horde_model_reference.util import atomic_write_json
+
+
+class GroupAlias(BaseModel):
+    """A mapping from one canonical group name to its known aliases."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    canonical: str
+    """The target group name that all aliases resolve to."""
+
+    aliases: list[str] = Field(default_factory=list)
+    """Base names that should be treated as members of the canonical group."""
+
+
+class GroupAliasStore:
+    """Thread-safe file-backed storage for group alias mappings.
+
+    Each entry maps a *canonical* group name to a list of *alias* base names.
+    When the grouping layer calls :meth:`resolve`, any alias is transparently
+    mapped back to its canonical name, collapsing multiple parser-produced
+    groups into one.
+    """
+
+    def __init__(self, *, file_path: Path) -> None:
+        """Create or load a store backed by the given JSON file.
+
+        Args:
+            file_path: Path to the JSON persistence file.
+
+        """
+        self._file_path = file_path
+        self._lock = RLock()
+        self._entries: dict[str, GroupAlias] = {}
+        # Reverse index: alias → canonical (built from _entries on load/mutate)
+        self._alias_to_canonical: dict[str, str] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self._file_path.exists():
+            return
+        try:
+            raw = json.loads(self._file_path.read_text(encoding="utf-8"))
+            for canonical, data in raw.items():
+                self._entries[canonical] = GroupAlias.model_validate({"canonical": canonical, **data})
+            self._rebuild_reverse_index()
+            logger.debug(f"Loaded {len(self._entries)} group alias entries from {self._file_path}")
+        except Exception:
+            logger.exception(f"Failed to load group aliases from {self._file_path}")
+
+    def _persist(self) -> None:
+        self._file_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {canonical: {"aliases": entry.aliases} for canonical, entry in self._entries.items()}
+        atomic_write_json(self._file_path, payload)
+
+    def _rebuild_reverse_index(self) -> None:
+        self._alias_to_canonical = {}
+        for canonical, entry in self._entries.items():
+            for alias in entry.aliases:
+                self._alias_to_canonical[alias] = canonical
+
+    def resolve(self, base_name: str) -> str:
+        """Return the canonical group name for *base_name*, or *base_name* itself.
+
+        This is the hot-path call wired into the grouping layer.
+
+        Args:
+            base_name: A parser-produced base model name.
+
+        Returns:
+            The canonical group name if *base_name* is a registered alias,
+            otherwise *base_name* unchanged.
+
+        """
+        with self._lock:
+            return self._alias_to_canonical.get(base_name, base_name)
+
+    def get(self, canonical: str) -> GroupAlias | None:
+        """Return the alias entry for *canonical*, or ``None``."""
+        with self._lock:
+            entry = self._entries.get(canonical)
+            return entry.model_copy(deep=True) if entry else None
+
+    def set_aliases(self, canonical: str, aliases: list[str]) -> None:
+        """Persist *aliases* for *canonical*, replacing any previous aliases.
+
+        Args:
+            canonical: The target group name.
+            aliases: Base names that should resolve to *canonical*.
+
+        Raises:
+            ValueError: If *canonical* appears in *aliases* (self-reference)
+                or if any alias is already claimed by a different canonical group.
+
+        """
+        with self._lock:
+            if canonical in aliases:
+                raise ValueError(f"Canonical name {canonical!r} cannot be its own alias")
+
+            # Check for conflicts with other canonical entries
+            for alias in aliases:
+                existing_owner = self._alias_to_canonical.get(alias)
+                if existing_owner is not None and existing_owner != canonical:
+                    raise ValueError(f"Alias {alias!r} is already registered under canonical group {existing_owner!r}")
+
+            self._entries[canonical] = GroupAlias(canonical=canonical, aliases=list(aliases))
+            self._rebuild_reverse_index()
+            self._persist()
+            logger.info(f"Saved {len(aliases)} aliases for canonical group '{canonical}'")
+
+    def add_alias(self, canonical: str, alias: str) -> None:
+        """Add a single *alias* to an existing or new canonical entry.
+
+        Args:
+            canonical: The target group name.
+            alias: A base name to add as an alias.
+
+        Raises:
+            ValueError: If *alias* equals *canonical* or is already registered
+                under a different canonical group.
+
+        """
+        with self._lock:
+            if alias == canonical:
+                raise ValueError(f"Cannot alias {canonical!r} to itself")
+
+            existing_owner = self._alias_to_canonical.get(alias)
+            if existing_owner is not None and existing_owner != canonical:
+                raise ValueError(f"Alias {alias!r} is already registered under canonical group {existing_owner!r}")
+
+            entry = self._entries.get(canonical)
+            if entry is None:
+                entry = GroupAlias(canonical=canonical, aliases=[])
+                self._entries[canonical] = entry
+
+            if alias not in entry.aliases:
+                entry.aliases.append(alias)
+                self._rebuild_reverse_index()
+                self._persist()
+                logger.info(f"Added alias '{alias}' → canonical '{canonical}'")
+
+    def remove_alias(self, canonical: str, alias: str) -> bool:
+        """Remove a single *alias* from a canonical entry.
+
+        Returns ``True`` if the alias was present and removed.
+        """
+        with self._lock:
+            entry = self._entries.get(canonical)
+            if entry is None or alias not in entry.aliases:
+                return False
+
+            entry.aliases.remove(alias)
+            if not entry.aliases:
+                del self._entries[canonical]
+            self._rebuild_reverse_index()
+            self._persist()
+            logger.info(f"Removed alias '{alias}' from canonical '{canonical}'")
+            return True
+
+    def delete(self, canonical: str) -> bool:
+        """Remove the entire alias entry for *canonical*.
+
+        Returns ``True`` if it existed.
+        """
+        with self._lock:
+            if canonical not in self._entries:
+                return False
+            del self._entries[canonical]
+            self._rebuild_reverse_index()
+            self._persist()
+            logger.info(f"Deleted all aliases for canonical group '{canonical}'")
+            return True
+
+    def list_all(self) -> dict[str, GroupAlias]:
+        """Return a deep copy of all alias entries."""
+        with self._lock:
+            return {k: v.model_copy(deep=True) for k, v in self._entries.items()}
+
+    def is_alias(self, name: str) -> bool:
+        """Return ``True`` if *name* is registered as an alias (not canonical)."""
+        with self._lock:
+            return name in self._alias_to_canonical
+
+    def get_canonical_for(self, alias: str) -> str | None:
+        """Return the canonical name that *alias* maps to, or ``None``."""
+        with self._lock:
+            return self._alias_to_canonical.get(alias)

--- a/src/horde_model_reference/group_families.py
+++ b/src/horde_model_reference/group_families.py
@@ -1,0 +1,312 @@
+"""File-backed persistence for related-group families.
+
+Provides a lightweight association layer between distinct model groups that
+share a conceptual relationship — for example, Mistral-Large, Mistral-Small,
+and Mistral-Nemo all belong to the "Mistral" family even though they are
+architecturally distinct models with their own groups.
+
+Families are purely informational metadata. They do not affect base name
+extraction, alias resolution, or group membership. They exist so that UIs
+and analytics can surface "see also" relationships between groups.
+
+Public API:
+    ``GroupFamily``       — Pydantic model representing a single family.
+    ``GroupFamilyStore``  — Thread-safe, file-backed CRUD for families.
+    ``detect_families``   — Heuristic prefix-based family suggestion from group names.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from threading import RLock
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from horde_model_reference.util import atomic_write_json
+
+
+class GroupFamily(BaseModel):
+    """Represents a named family of related model groups.
+
+    Attributes:
+        family_name: Human-readable identifier for this family (e.g., ``"Mistral"``).
+        members: Group base-names that belong to this family.
+
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    family_name: str
+    members: list[str] = Field(default_factory=list)
+
+
+class GroupFamilyStore:
+    """Thread-safe, file-backed store for related-group families.
+
+    Each family maps a descriptive name to a set of group base-names.
+    A group may belong to at most one family — assigning it to a second
+    family raises ``ValueError``.
+
+    The reverse index (``_group_to_family``) enables O(1) lookups from
+    any group name to its family.
+
+    Attributes:
+        _file_path: Filesystem location for JSON persistence.
+        _families: family_name → ``GroupFamily`` mapping.
+        _group_to_family: group_name → family_name reverse index.
+
+    """
+
+    def __init__(self, *, file_path: Path) -> None:
+        """Construct the store and load persisted state if the file exists.
+
+        Args:
+            file_path: Path to the JSON file used for persistence.
+
+        """
+        self._file_path = file_path
+        self._lock = RLock()
+        self._families: dict[str, GroupFamily] = {}
+        self._group_to_family: dict[str, str] = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Read persisted families from disk, rebuilding the reverse index."""
+        if not self._file_path.exists():
+            return
+
+        try:
+            raw = json.loads(self._file_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            logger.warning(f"Failed to load group families from {self._file_path}")
+            return
+
+        for family_name, entry in raw.items():
+            family = GroupFamily.model_validate(entry)
+            self._families[family_name] = family
+            for member in family.members:
+                self._group_to_family[member] = family_name
+
+    def _persist(self) -> None:
+        """Write current state to disk atomically."""
+        payload = {
+            family_name: family.model_dump(mode="json") for family_name, family in sorted(self._families.items())
+        }
+        atomic_write_json(self._file_path, payload)
+
+    def get_family(self, family_name: str) -> GroupFamily | None:
+        """Return a family by name, or ``None`` if not found.
+
+        Args:
+            family_name: The family identifier to look up.
+
+        Returns:
+            The matching ``GroupFamily`` or ``None``.
+
+        """
+        with self._lock:
+            family = self._families.get(family_name)
+            if family is None:
+                return None
+            return family.model_copy(deep=True)
+
+    def get_family_for_group(self, group_name: str) -> GroupFamily | None:
+        """Return the family that *group_name* belongs to, or ``None``.
+
+        Args:
+            group_name: A model group base-name.
+
+        Returns:
+            A deep copy of the family, or ``None`` if the group has no family.
+
+        """
+        with self._lock:
+            family_name = self._group_to_family.get(group_name)
+            if family_name is None:
+                return None
+            family = self._families.get(family_name)
+            if family is None:
+                return None
+            return family.model_copy(deep=True)
+
+    def list_all(self) -> dict[str, GroupFamily]:
+        """Return a deep copy of every family.
+
+        Returns:
+            Mapping of family_name → ``GroupFamily`` (copies).
+
+        """
+        with self._lock:
+            return {family_name: family.model_copy(deep=True) for family_name, family in self._families.items()}
+
+    def set_family(self, family_name: str, member_groups: list[str]) -> None:
+        """Create or replace a family, assigning the given members.
+
+        Any previous members of this family that are not in *member_groups*
+        are released. New members must not already belong to a different family.
+
+        Args:
+            family_name: Identifier for the family.
+            member_groups: Group base-names to include.
+
+        Raises:
+            ValueError: If a member already belongs to a different family,
+                or if *member_groups* is empty.
+
+        """
+        if not member_groups:
+            raise ValueError("A family must have at least one member group.")
+
+        with self._lock:
+            # Validate that no member is already claimed by another family
+            for group_name in member_groups:
+                existing_family = self._group_to_family.get(group_name)
+                if existing_family is not None and existing_family != family_name:
+                    raise ValueError(
+                        f"Group '{group_name}' already belongs to family '{existing_family}'. "
+                        f"Remove it from that family first."
+                    )
+
+            # Release any previously assigned members of this family
+            old_family = self._families.get(family_name)
+            if old_family is not None:
+                for old_member in old_family.members:
+                    if old_member not in member_groups:
+                        self._group_to_family.pop(old_member, None)
+
+            family = GroupFamily(family_name=family_name, members=sorted(set(member_groups)))
+            self._families[family_name] = family
+            for group_name in family.members:
+                self._group_to_family[group_name] = family_name
+
+            self._persist()
+            logger.debug(f"Set family '{family_name}' with {len(family.members)} members")
+
+    def add_member(self, family_name: str, group_name: str) -> None:
+        """Add a single group to an existing family.
+
+        Args:
+            family_name: The target family.
+            group_name: The group to add.
+
+        Raises:
+            KeyError: If *family_name* does not exist.
+            ValueError: If *group_name* already belongs to a different family.
+
+        """
+        with self._lock:
+            family = self._families.get(family_name)
+            if family is None:
+                raise KeyError(f"Family '{family_name}' does not exist.")
+
+            existing = self._group_to_family.get(group_name)
+            if existing is not None and existing != family_name:
+                raise ValueError(f"Group '{group_name}' already belongs to family '{existing}'.")
+
+            if group_name not in family.members:
+                family.members = sorted(set(family.members) | {group_name})
+                self._group_to_family[group_name] = family_name
+                self._persist()
+
+    def remove_member(self, family_name: str, group_name: str) -> bool:
+        """Remove a single group from a family.
+
+        If the family becomes empty after removal, it is deleted entirely.
+
+        Args:
+            family_name: The family to modify.
+            group_name: The group to remove.
+
+        Returns:
+            ``True`` if the group was found and removed.
+
+        """
+        with self._lock:
+            family = self._families.get(family_name)
+            if family is None or group_name not in family.members:
+                return False
+
+            family.members = [m for m in family.members if m != group_name]
+            self._group_to_family.pop(group_name, None)
+
+            if not family.members:
+                del self._families[family_name]
+                logger.debug(f"Deleted empty family '{family_name}'")
+            else:
+                self._families[family_name] = family
+
+            self._persist()
+            return True
+
+    def delete(self, family_name: str) -> bool:
+        """Delete an entire family, releasing all its members.
+
+        Args:
+            family_name: The family to delete.
+
+        Returns:
+            ``True`` if the family existed and was deleted.
+
+        """
+        with self._lock:
+            family = self._families.pop(family_name, None)
+            if family is None:
+                return False
+
+            for member in family.members:
+                self._group_to_family.pop(member, None)
+
+            self._persist()
+            logger.debug(f"Deleted family '{family_name}' ({len(family.members)} members released)")
+            return True
+
+
+def detect_families(
+    group_names: list[str],
+    *,
+    min_prefix_length: int = 3,
+    min_family_size: int = 2,
+) -> dict[str, list[str]]:
+    """Suggest family groupings from group names using shared prefix heuristics.
+
+    Groups that share a common hyphen-delimited prefix are candidates for the
+    same family. When shorter and longer prefixes overlap, the longest prefix
+    that captures at least *min_family_size* groups wins, and its members are
+    excluded from shorter prefix families.
+
+    This is a suggestion engine — results should be reviewed by an admin before
+    persisting via ``GroupFamilyStore.set_family()``.
+
+    Args:
+        group_names: Distinct group base-names to analyze.
+        min_prefix_length: Minimum character length for a prefix to be considered.
+        min_family_size: Minimum number of groups required to form a family.
+
+    Returns:
+        Mapping of suggested family prefix → list of member group names.
+
+    """
+    prefix_to_groups: dict[str, set[str]] = defaultdict(set)
+
+    for group_name in group_names:
+        parts = group_name.split("-")
+        for depth in range(len(parts) - 1, 0, -1):
+            prefix = "-".join(parts[:depth])
+            if len(prefix) >= min_prefix_length:
+                prefix_to_groups[prefix].add(group_name)
+
+    # Deduplicate: longest prefix wins, claim its members
+    sorted_prefixes = sorted(prefix_to_groups.keys(), key=len, reverse=True)
+    claimed: set[str] = set()
+    result: dict[str, list[str]] = {}
+
+    for prefix in sorted_prefixes:
+        unclaimed = sorted(prefix_to_groups[prefix] - claimed)
+        if len(unclaimed) >= min_family_size:
+            result[prefix] = unclaimed
+            claimed.update(unclaimed)
+
+    return dict(sorted(result.items()))

--- a/src/horde_model_reference/group_schema_store.py
+++ b/src/horde_model_reference/group_schema_store.py
@@ -1,0 +1,94 @@
+"""File-backed persistence for text model group naming schemas."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import RLock
+
+from loguru import logger
+
+from horde_model_reference.group_aliases import GroupAliasStore
+from horde_model_reference.model_reference_records import TextModelGroupNameSchema
+from horde_model_reference.util import atomic_write_json
+
+
+class GroupSchemaStore:
+    """Thread-safe file-backed storage for per-group naming schemas.
+
+    When an optional :class:`GroupAliasStore` is provided, :meth:`get`
+    transparently resolves aliases so that schemas stored under a
+    canonical group name are also returned for alias lookups.
+    """
+
+    def __init__(
+        self,
+        *,
+        file_path: Path,
+        alias_store: GroupAliasStore | None = None,
+    ) -> None:
+        """Create a store backed by the given JSON file.
+
+        Args:
+            file_path: Path to the JSON persistence file.
+            alias_store: Optional alias store used to resolve lookups.
+
+        """
+        self._file_path = file_path
+        self._lock = RLock()
+        self._schemas: dict[str, TextModelGroupNameSchema] = {}
+        self._alias_store = alias_store
+        self._load()
+
+    def _load(self) -> None:
+        if not self._file_path.exists():
+            return
+        try:
+            raw = json.loads(self._file_path.read_text(encoding="utf-8"))
+            for group_name, schema_data in raw.items():
+                self._schemas[group_name] = TextModelGroupNameSchema.model_validate(schema_data)
+            logger.debug(f"Loaded {len(self._schemas)} group naming schemas from {self._file_path}")
+        except Exception:
+            logger.exception(f"Failed to load group schemas from {self._file_path}")
+
+    def _persist(self) -> None:
+        self._file_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {name: schema.model_dump(mode="json") for name, schema in self._schemas.items()}
+        atomic_write_json(self._file_path, payload)
+
+    def get(self, group_name: str) -> TextModelGroupNameSchema | None:
+        """Return the persisted schema for *group_name*, or ``None``.
+
+        If an alias store is configured and no direct match exists, the
+        alias store is consulted to resolve *group_name* to its canonical
+        form before retrying the lookup.
+        """
+        with self._lock:
+            schema = self._schemas.get(group_name)
+            if schema is None and self._alias_store is not None:
+                canonical = self._alias_store.resolve(group_name)
+                if canonical != group_name:
+                    schema = self._schemas.get(canonical)
+            return schema.model_copy() if schema else None
+
+    def set(self, group_name: str, schema: TextModelGroupNameSchema) -> None:
+        """Persist a custom naming schema for *group_name*."""
+        with self._lock:
+            self._schemas[group_name] = schema.model_copy()
+            self._persist()
+            logger.info(f"Saved custom naming schema for group '{group_name}'")
+
+    def delete(self, group_name: str) -> bool:
+        """Remove the custom schema for *group_name*. Returns ``True`` if it existed."""
+        with self._lock:
+            if group_name not in self._schemas:
+                return False
+            del self._schemas[group_name]
+            self._persist()
+            logger.info(f"Deleted custom naming schema for group '{group_name}'")
+            return True
+
+    def list_all(self) -> dict[str, TextModelGroupNameSchema]:
+        """Return a copy of all persisted schemas."""
+        with self._lock:
+            return {name: schema.model_copy() for name, schema in self._schemas.items()}

--- a/src/horde_model_reference/model_reference_manager.py
+++ b/src/horde_model_reference/model_reference_manager.py
@@ -20,6 +20,9 @@ from horde_model_reference.backends import (
     HTTPBackend,
     ModelReferenceBackend,
 )
+from horde_model_reference.group_aliases import GroupAliasStore
+from horde_model_reference.group_families import GroupFamilyStore
+from horde_model_reference.group_schema_store import GroupSchemaStore
 from horde_model_reference.meta_consts import MODEL_REFERENCE_CATEGORY, categories_managed_elsewhere
 from horde_model_reference.model_reference_records import (
     MODEL_RECORD_TYPE_LOOKUP,
@@ -107,6 +110,9 @@ class ModelReferenceManager:
     _async_prefetch_task: asyncio.Task[None] | None = None
     _audit_writer: AuditTrailWriter | None = None
     _pending_queue_service: PendingQueueService | None = None
+    _group_alias_store: GroupAliasStore | None = None
+    _group_family_store: GroupFamilyStore | None = None
+    _group_schema_store: GroupSchemaStore | None = None
 
     _lock: RLock = RLock()
 
@@ -330,9 +336,22 @@ class ModelReferenceManager:
                     cls._instance._pending_queue_service = cls._build_pending_queue_service(
                         audit_writer=audit_writer,
                     )
+                    cls._instance._group_alias_store = GroupAliasStore(
+                        file_path=horde_model_reference_paths.group_aliases_path,
+                    )
+                    cls._instance._group_family_store = GroupFamilyStore(
+                        file_path=horde_model_reference_paths.group_families_path,
+                    )
+                    cls._instance._group_schema_store = GroupSchemaStore(
+                        file_path=horde_model_reference_paths.group_schemas_path,
+                        alias_store=cls._instance._group_alias_store,
+                    )
                 else:
                     cls._instance._audit_writer = None
                     cls._instance._pending_queue_service = None
+                    cls._instance._group_alias_store = None
+                    cls._instance._group_family_store = None
+                    cls._instance._group_schema_store = None
                 cls._instance._cached_records = {}
                 cls._instance._deferred_prefetch_handle = None
                 cls._instance._async_prefetch_task = None
@@ -485,6 +504,21 @@ class ModelReferenceManager:
     def pending_queue_service(self) -> PendingQueueService | None:
         """Return the pending queue service when queueing is enabled."""
         return self._pending_queue_service
+
+    @property
+    def group_alias_store(self) -> GroupAliasStore | None:
+        """Return the group alias store when in PRIMARY mode."""
+        return self._group_alias_store
+
+    @property
+    def group_family_store(self) -> GroupFamilyStore | None:
+        """Return the related-group family store when in PRIMARY mode."""
+        return self._group_family_store
+
+    @property
+    def group_schema_store(self) -> GroupSchemaStore | None:
+        """Return the group schema store when in PRIMARY mode."""
+        return self._group_schema_store
 
     @property
     def deferred_prefetch_handle(self) -> DeferredPrefetchHandle | None:

--- a/src/horde_model_reference/model_reference_records.py
+++ b/src/horde_model_reference/model_reference_records.py
@@ -364,6 +364,25 @@ class TextGenerationModelRecord(GenericModelRecord):
     settings: dict[str, int | float | str | list[int] | list[float] | list[str] | bool] | None = None
     text_model_group: str | None = None
     """The base model group name for grouping model variants together."""
+    name_schema_exception: str | None = None
+    """If set, this model does not follow the group's naming schema. The value is the reason."""
+
+
+class TextModelGroupNameSchema(BaseModel):
+    """Persisted naming convention for a text model group.
+
+    When saved, overrides the inferred schema from ``infer_name_format()``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    separator: str = "-"
+    part_order: list[str] = Field(default_factory=lambda: ["base", "size", "variant", "version", "quant"])
+    author_included: bool = True
+    common_author: str | None = None
+    template: str | None = None
+    extra_parts: list[str] = Field(default_factory=list)
+    """Free-form labels for name segments outside the five primary categories (e.g., ``["date"]``)."""
 
 
 @register_record_type(MODEL_REFERENCE_CATEGORY.blip)

--- a/src/horde_model_reference/path_consts.py
+++ b/src/horde_model_reference/path_consts.py
@@ -57,6 +57,15 @@ AUDIT_FOLDER_NAME: str = "audit"
 PENDING_QUEUE_FOLDER_NAME: str = "pending_queue"
 """Folder storing pending change queue persistence."""
 
+GROUP_SCHEMAS_FILENAME: str = "text_generation_group_schemas.json"
+"""Filename for persisted text model group naming schemas."""
+
+GROUP_ALIASES_FILENAME: str = "text_generation_group_aliases.json"
+"""Filename for persisted text model group alias mappings."""
+
+GROUP_FAMILIES_FILENAME: str = "text_generation_group_families.json"
+"""Filename for persisted related-group family associations."""
+
 
 class HordeModelReferencePaths:
     """A helper class to manage local and remote model reference paths."""
@@ -112,6 +121,21 @@ class HordeModelReferencePaths:
 
         subdir = horde_model_reference_settings.pending_queue.relative_subdir or PENDING_QUEUE_FOLDER_NAME
         return self.base_path.joinpath(subdir)
+
+    @property
+    def group_schemas_path(self) -> Path:
+        """Return the path to the text model group naming schemas file."""
+        return self.base_path.joinpath(GROUP_SCHEMAS_FILENAME)
+
+    @property
+    def group_aliases_path(self) -> Path:
+        """Return the path to the text model group alias mappings file."""
+        return self.base_path.joinpath(GROUP_ALIASES_FILENAME)
+
+    @property
+    def group_families_path(self) -> Path:
+        """Return the path to the related-group family associations file."""
+        return self.base_path.joinpath(GROUP_FAMILIES_FILENAME)
 
     log_folder: Path
 

--- a/src/horde_model_reference/query_fields.py
+++ b/src/horde_model_reference/query_fields.py
@@ -229,6 +229,7 @@ class TextFields(GenericFields):
     instruct_format: FieldRef = FieldRef("instruct_format")
     settings: FieldRef = FieldRef("settings")
     text_model_group: FieldRef = FieldRef("text_model_group")
+    name_schema_exception: FieldRef = FieldRef("name_schema_exception")
 
 
 class ControlNetFields(GenericFields):

--- a/src/horde_model_reference/service/shared.py
+++ b/src/horde_model_reference/service/shared.py
@@ -386,23 +386,33 @@ def get_model_reference_manager() -> ModelReferenceManager:
     return ModelReferenceManager()
 
 
+def assert_primary_mode(manager: ModelReferenceManager) -> None:
+    """Ensure the backend is in PRIMARY mode (supports writes), regardless of canonical format.
+
+    Use for metadata-only write operations (schemas, aliases, families) that don't
+    modify model records and are not gated by the canonical format setting.
+    """
+    if not manager.backend.supports_writes():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "This instance is in REPLICA mode and does not support write operations. "
+                "Only PRIMARY instances can modify data."
+            ),
+        )
+
+
 def assert_canonical_write_enabled(
     manager: ModelReferenceManager,
     *,
     canonical_format: CanonicalFormat,
 ) -> None:
     """Ensure that writes are attempted only when the canonical format allows them."""
+    assert_primary_mode(manager)
+
     backend = manager.backend
     expected_format = horde_model_reference_settings.canonical_format
     if canonical_format == CanonicalFormat.v2:
-        if not backend.supports_writes():
-            raise HTTPException(
-                status_code=503,
-                detail=(
-                    "This instance is in REPLICA mode and does not support write operations. "
-                    "Only PRIMARY instances can queue model changes."
-                ),
-            )
         if expected_format != canonical_format:
             raise HTTPException(
                 status_code=503,

--- a/src/horde_model_reference/service/v2/routers/text_utils.py
+++ b/src/horde_model_reference/service/v2/routers/text_utils.py
@@ -20,14 +20,18 @@ from horde_model_reference.analytics.text_model_parser import (
     parse_text_model_name,
 )
 from horde_model_reference.audit.events import AuditOperation
+from horde_model_reference.group_aliases import GroupAliasStore
+from horde_model_reference.group_families import GroupFamilyStore, detect_families
+from horde_model_reference.group_schema_store import GroupSchemaStore
 from horde_model_reference.meta_consts import MODEL_REFERENCE_CATEGORY
+from horde_model_reference.model_reference_records import TextModelGroupNameSchema
 from horde_model_reference.service.pending_queue.dependencies import require_pending_queue_service
 from horde_model_reference.service.shared import (
     authenticate_queue_requestor,
     get_model_reference_manager,
     header_auth_scheme,
 )
-from horde_model_reference.service.v2.routers.write_validations import assert_v2_write_enabled
+from horde_model_reference.service.v2.routers.write_validations import assert_primary_write_enabled
 from horde_model_reference.text_backend_names import has_legacy_text_backend_prefix
 
 router = APIRouter()
@@ -36,6 +40,14 @@ _CATEGORY = MODEL_REFERENCE_CATEGORY.text_generation
 
 # Fields that can be shared/edited at group level
 _COMMON_FIELD_KEYS = ("baseline", "description", "url", "nsfw", "tags", "style", "instruct_format")
+
+
+class ExtraPartInfo(BaseModel):
+    """A name segment that didn't match any primary part category."""
+
+    value: str
+    position: int
+    inferred_type: str
 
 
 class ParsedNameResponse(BaseModel):
@@ -48,6 +60,7 @@ class ParsedNameResponse(BaseModel):
     quant: str | None = None
     version: str | None = None
     suggested_group: str
+    extras: list[ExtraPartInfo] = []
 
 
 class ParsedNameInfo(BaseModel):
@@ -58,6 +71,7 @@ class ParsedNameInfo(BaseModel):
     variant: str | None = None
     quant: str | None = None
     version: str | None = None
+    extras: list[ExtraPartInfo] = []
 
 
 class GroupMemberInfo(BaseModel):
@@ -86,6 +100,14 @@ class NameFormatInfo(BaseModel):
     author_included: bool
     common_author: str | None = None
     template: str
+    extra_parts: list[str] = []
+
+
+class NameExceptionInfo(BaseModel):
+    """A member that does not follow the group naming schema."""
+
+    name: str
+    reason: str
 
 
 class GroupMembersResponse(BaseModel):
@@ -104,6 +126,9 @@ class GroupMembersResponse(BaseModel):
     name_format: NameFormatInfo
     canonical_count: int
     backend_duplicate_count: int
+    name_schema_is_custom: bool = False
+    exception_members: list[NameExceptionInfo] = []
+    related_family: GroupFamilyResponse | None = None
 
 
 class DistinctBaselinesResponse(BaseModel):
@@ -151,6 +176,80 @@ class BatchUpdateResponse(BaseModel):
     updated_count: int
     batch_id: str
     pending_change_ids: list[int]
+
+
+class GroupNameSchemaResponse(BaseModel):
+    """Response for a group's naming schema."""
+
+    group_name: str
+    name_schema: TextModelGroupNameSchema
+    is_custom: bool
+
+
+class GroupNameSchemaUpdateRequest(BaseModel):
+    """Partial update for a group's naming schema."""
+
+    separator: str | None = None
+    part_order: list[str] | None = None
+    author_included: bool | None = None
+    common_author: str | None = None
+    template: str | None = None
+    extra_parts: list[str] | None = None
+
+
+class NameExceptionRequest(BaseModel):
+    """Set or clear a name schema exception on a model."""
+
+    reason: str | None
+
+
+class GroupListResponse(BaseModel):
+    """Response listing all text model group names."""
+
+    groups: list[str]
+
+
+class GroupHealthIssue(BaseModel):
+    """A single health problem detected for a group."""
+
+    group_name: str
+    issue_type: str
+    message: str
+    severity: str = "warning"
+
+
+class GroupSummaryEntry(BaseModel):
+    """Enriched metadata for a single text model group."""
+
+    group_name: str
+    canonical_count: int
+    backend_duplicate_count: int
+    has_custom_schema: bool = False
+    family_name: str | None = None
+    alias_canonical: str | None = None
+    aliases: list[str] = []
+    available_sizes: list[str] = []
+    health_issues: list[GroupHealthIssue] = []
+
+
+class GroupsSummaryResponse(BaseModel):
+    """Enriched overview of all text model groups."""
+
+    groups: list[GroupSummaryEntry]
+    total_groups: int
+    total_models: int
+    groups_with_families: int
+    groups_with_aliases: int
+    groups_with_issues: int
+
+
+class GroupHealthResponse(BaseModel):
+    """Aggregate health check across all text model groups."""
+
+    issues: list[GroupHealthIssue]
+    total_groups_checked: int
+    groups_with_issues: int
+    issue_counts_by_type: dict[str, int]
 
 
 def _get_all_text_models(manager: ModelReferenceManager) -> dict[str, dict[str, Any]]:
@@ -245,10 +344,15 @@ def _compose_name_from_parts(
 )
 def parse_name(
     name: Annotated[str, Query(description="The model name to parse")],
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
 ) -> ParsedNameResponse:
     """Parse a text model name into base name, size, variant, and quantization components."""
     parsed = parse_text_model_name(name)
     suggested_group = get_base_model_name(name)
+
+    alias_store = manager.group_alias_store
+    if alias_store is not None:
+        suggested_group = alias_store.resolve(suggested_group)
 
     return ParsedNameResponse(
         original_name=name,
@@ -258,6 +362,10 @@ def parse_name(
         quant=parsed.quant,
         version=parsed.version,
         suggested_group=suggested_group,
+        extras=[
+            ExtraPartInfo(value=e.value, position=e.position, inferred_type=e.inferred_type.value)
+            for e in parsed.extras
+        ],
     )
 
 
@@ -315,6 +423,10 @@ def get_group(
                 variant=parsed.variant,
                 quant=parsed.quant,
                 version=parsed.version,
+                extras=[
+                    ExtraPartInfo(value=e.value, position=e.position, inferred_type=e.inferred_type.value)
+                    for e in parsed.extras
+                ],
             ),
             parameters=data.get("parameters"),
             baseline=data.get("baseline"),
@@ -370,16 +482,49 @@ def get_group(
     canonical_count = len(canonical_members)
     dup_count = len(members) - canonical_count
 
-    # Infer naming convention from canonical member names
-    canonical_names = [k for k, _ in canonical_members]
-    schema = infer_name_format(canonical_names)
-    name_format = NameFormatInfo(
-        separator=schema.separator,
-        part_order=schema.part_order,
-        author_included=schema.author_included,
-        common_author=schema.common_author,
-        template=schema.template,
-    )
+    # Use persisted schema if available, otherwise infer from member names
+    name_schema_is_custom = False
+    store = manager.group_schema_store
+    persisted = store.get(group_name) if store else None
+    if persisted:
+        name_schema_is_custom = True
+        name_format = NameFormatInfo(
+            separator=persisted.separator,
+            part_order=persisted.part_order,
+            author_included=persisted.author_included,
+            common_author=persisted.common_author,
+            template=persisted.template or "",
+            extra_parts=persisted.extra_parts,
+        )
+    else:
+        canonical_names = [k for k, _ in canonical_members]
+        schema = infer_name_format(canonical_names)
+        name_format = NameFormatInfo(
+            separator=schema.separator,
+            part_order=schema.part_order,
+            author_included=schema.author_included,
+            common_author=schema.common_author,
+            template=schema.template,
+            extra_parts=schema.extra_parts,
+        )
+
+    # Collect members with naming schema exceptions
+    exception_members: list[NameExceptionInfo] = []
+    for key, data in canonical_members:
+        reason = data.get("name_schema_exception")
+        if reason:
+            exception_members.append(NameExceptionInfo(name=key, reason=reason))
+
+    # Look up related family for this group
+    related_family: GroupFamilyResponse | None = None
+    family_store = manager.group_family_store
+    if family_store is not None:
+        family = family_store.get_family_for_group(group_name)
+        if family is not None:
+            related_family = GroupFamilyResponse(
+                family_name=family.family_name,
+                members=family.members,
+            )
 
     return GroupMembersResponse(
         group_name=group_name,
@@ -395,6 +540,9 @@ def get_group(
         name_format=name_format,
         canonical_count=canonical_count,
         backend_duplicate_count=dup_count,
+        name_schema_is_custom=name_schema_is_custom,
+        exception_members=exception_members,
+        related_family=related_family,
     )
 
 
@@ -473,7 +621,7 @@ async def update_group_common_fields(
     Creates one PendingChangeRecord per canonical member with a shared batch_id.
     """
     requestor = await authenticate_queue_requestor(apikey)
-    assert_v2_write_enabled(manager)
+    assert_primary_write_enabled(manager)
 
     all_models = _get_all_text_models(manager)
     raw_members = _get_group_members(all_models, group_name)
@@ -538,3 +686,888 @@ async def update_group_common_fields(
         status_code=status.HTTP_202_ACCEPTED,
         content=response.model_dump(mode="json"),
     )
+
+
+@router.get(
+    "/text_generation/groups",
+    response_model=GroupListResponse,
+    summary="List all text model group names",
+    tags=["text_utils"],
+)
+def list_groups(
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+) -> GroupListResponse:
+    """Return sorted distinct ``text_model_group`` values across all text models."""
+    all_models = _get_all_text_models(manager)
+    groups: set[str] = set()
+    for data in all_models.values():
+        group = data.get("text_model_group")
+        if isinstance(group, str) and group:
+            groups.add(group)
+    return GroupListResponse(groups=sorted(groups))
+
+
+def _collect_group_health_issues(
+    group_name: str,
+    members: list[tuple[str, dict[str, Any]]],
+) -> list[GroupHealthIssue]:
+    """Check a group's canonical members for common problems.
+
+    Returns a list of issues found. Called by both the summary and health
+    endpoints to avoid duplicating diagnostic logic.
+    """
+    issues: list[GroupHealthIssue] = []
+
+    if len(members) == 1:
+        issues.append(
+            GroupHealthIssue(
+                group_name=group_name,
+                issue_type="singleton_group",
+                message="Group has only 1 canonical model — may not need a group",
+            )
+        )
+
+    baselines: set[str] = set()
+    nsfw_values: set[bool] = set()
+    missing_desc_count = 0
+    missing_baseline_count = 0
+
+    for _, data in members:
+        bl = data.get("baseline")
+        if isinstance(bl, str) and bl:
+            baselines.add(bl)
+        else:
+            missing_baseline_count += 1
+        nsfw = data.get("nsfw")
+        if isinstance(nsfw, bool):
+            nsfw_values.add(nsfw)
+        if not data.get("description"):
+            missing_desc_count += 1
+
+    if len(baselines) > 1:
+        issues.append(
+            GroupHealthIssue(
+                group_name=group_name,
+                issue_type="inconsistent_baseline",
+                message=f"Members have different baselines: {', '.join(sorted(baselines))}",
+            )
+        )
+
+    if len(nsfw_values) > 1:
+        issues.append(
+            GroupHealthIssue(
+                group_name=group_name,
+                issue_type="inconsistent_nsfw",
+                message="Members have different NSFW flags",
+            )
+        )
+
+    if missing_baseline_count > 0:
+        issues.append(
+            GroupHealthIssue(
+                group_name=group_name,
+                issue_type="missing_baseline",
+                message=f"{missing_baseline_count} member(s) missing baseline",
+            )
+        )
+
+    if missing_desc_count > 0:
+        issues.append(
+            GroupHealthIssue(
+                group_name=group_name,
+                issue_type="missing_description",
+                message=f"{missing_desc_count} member(s) missing description",
+                severity="info",
+            )
+        )
+
+    return issues
+
+
+@router.get(
+    "/text_generation/groups/summary",
+    response_model=GroupsSummaryResponse,
+    summary="Enriched overview of all text model groups",
+    tags=["text_utils"],
+)
+def list_groups_summary(
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+) -> GroupsSummaryResponse:
+    """Return per-group metadata including member counts, family/alias info, and health flags.
+
+    Designed to power a group management overview UI in a single request.
+    """
+    all_models = _get_all_text_models(manager)
+
+    # Bucket models by group
+    groups_map: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+    for key, data in all_models.items():
+        group = data.get("text_model_group")
+        if isinstance(group, str) and group:
+            groups_map.setdefault(group, []).append((key, data))
+
+    schema_store = manager.group_schema_store
+    alias_store = manager.group_alias_store
+    family_store = manager.group_family_store
+
+    total_models = 0
+    groups_with_families = 0
+    groups_with_aliases = 0
+    groups_with_issues = 0
+    entries: list[GroupSummaryEntry] = []
+
+    for group_name in sorted(groups_map):
+        raw_members = groups_map[group_name]
+        canonical = [(k, d) for k, d in raw_members if not has_legacy_text_backend_prefix(k)]
+        dups = len(raw_members) - len(canonical)
+        total_models += len(raw_members)
+
+        # Schema
+        has_custom = bool(schema_store and schema_store.get(group_name))
+
+        # Family
+        family_name: str | None = None
+        if family_store:
+            fam = family_store.get_family_for_group(group_name)
+            if fam:
+                family_name = fam.family_name
+                groups_with_families += 1
+
+        # Aliases
+        alias_canonical: str | None = None
+        aliases: list[str] = []
+        if alias_store:
+            resolved = alias_store.resolve(group_name)
+            if resolved != group_name:
+                alias_canonical = resolved
+                groups_with_aliases += 1
+            else:
+                alias_entry = alias_store.get(group_name)
+                if alias_entry and alias_entry.aliases:
+                    aliases = alias_entry.aliases
+                    groups_with_aliases += 1
+
+        # Sizes
+        sizes: set[str] = set()
+        for key, _ in canonical:
+            parse_target = key
+            for prefix in ("aphrodite/", "koboldcpp/"):
+                if key.startswith(prefix):
+                    parse_target = key[len(prefix) :]
+                    break
+            parsed = parse_text_model_name(parse_target)
+            if parsed.size:
+                sizes.add(parsed.size)
+
+        # Health
+        health_issues = _collect_group_health_issues(group_name, canonical)
+        if health_issues:
+            groups_with_issues += 1
+
+        entries.append(
+            GroupSummaryEntry(
+                group_name=group_name,
+                canonical_count=len(canonical),
+                backend_duplicate_count=dups,
+                has_custom_schema=has_custom,
+                family_name=family_name,
+                alias_canonical=alias_canonical,
+                aliases=aliases,
+                available_sizes=sorted(sizes),
+                health_issues=health_issues,
+            )
+        )
+
+    return GroupsSummaryResponse(
+        groups=entries,
+        total_groups=len(entries),
+        total_models=total_models,
+        groups_with_families=groups_with_families,
+        groups_with_aliases=groups_with_aliases,
+        groups_with_issues=groups_with_issues,
+    )
+
+
+@router.get(
+    "/text_generation/groups/health",
+    response_model=GroupHealthResponse,
+    summary="Health check across all text model groups",
+    tags=["text_utils"],
+)
+def check_groups_health(
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+) -> GroupHealthResponse:
+    """Scan all text model groups for common problems.
+
+    Returns an aggregate list of issues sorted by severity, useful for
+    admin triage dashboards.
+    """
+    all_models = _get_all_text_models(manager)
+
+    groups_map: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+    for key, data in all_models.items():
+        group = data.get("text_model_group")
+        if isinstance(group, str) and group:
+            groups_map.setdefault(group, []).append((key, data))
+
+    all_issues: list[GroupHealthIssue] = []
+    groups_with_issues_set: set[str] = set()
+    issue_counts: dict[str, int] = {}
+
+    for group_name in sorted(groups_map):
+        raw_members = groups_map[group_name]
+        canonical = [(k, d) for k, d in raw_members if not has_legacy_text_backend_prefix(k)]
+
+        issues = _collect_group_health_issues(group_name, canonical)
+        if issues:
+            groups_with_issues_set.add(group_name)
+            all_issues.extend(issues)
+            for issue in issues:
+                issue_counts[issue.issue_type] = issue_counts.get(issue.issue_type, 0) + 1
+
+    return GroupHealthResponse(
+        issues=all_issues,
+        total_groups_checked=len(groups_map),
+        groups_with_issues=len(groups_with_issues_set),
+        issue_counts_by_type=issue_counts,
+    )
+
+
+def _require_group_schema_store(manager: ModelReferenceManager) -> GroupSchemaStore:
+    """Return the group schema store or raise 503 if unavailable."""
+    store = manager.group_schema_store
+    if store is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Group schema storage is not available (backend may be in REPLICA mode).",
+        )
+    return store
+
+
+@router.get(
+    "/text_generation/group/{group_name}/name_schema",
+    response_model=GroupNameSchemaResponse,
+    summary="Get the naming schema for a text model group",
+    tags=["text_utils"],
+)
+def get_group_name_schema(
+    group_name: str,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+) -> GroupNameSchemaResponse:
+    """Return the persisted naming schema if one exists, otherwise infer from member names."""
+    store = manager.group_schema_store
+    persisted = store.get(group_name) if store else None
+    if persisted:
+        return GroupNameSchemaResponse(
+            group_name=group_name,
+            name_schema=persisted,
+            is_custom=True,
+        )
+
+    # Fall back to inferred schema
+    all_models = _get_all_text_models(manager)
+    raw_members = _get_group_members(all_models, group_name)
+    canonical_names = [k for k, d in raw_members if not has_legacy_text_backend_prefix(k)]
+
+    if not canonical_names:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No models found in group '{group_name}'",
+        )
+
+    inferred = infer_name_format(canonical_names)
+    return GroupNameSchemaResponse(
+        group_name=group_name,
+        name_schema=TextModelGroupNameSchema(
+            separator=inferred.separator,
+            part_order=inferred.part_order,
+            author_included=inferred.author_included,
+            common_author=inferred.common_author,
+            template=inferred.template,
+        ),
+        is_custom=False,
+    )
+
+
+@router.put(
+    "/text_generation/group/{group_name}/name_schema",
+    response_model=GroupNameSchemaResponse,
+    summary="Save a custom naming schema for a text model group",
+    tags=["text_utils"],
+)
+async def update_group_name_schema(
+    group_name: str,
+    request: GroupNameSchemaUpdateRequest,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    apikey: Annotated[str, Depends(header_auth_scheme)],
+) -> GroupNameSchemaResponse:
+    """Persist a custom naming schema for a text model group."""
+    requestor = await authenticate_queue_requestor(apikey)
+    assert_primary_write_enabled(manager)
+
+    store = _require_group_schema_store(manager)
+
+    # Merge with existing persisted schema (or defaults) for partial updates
+    existing = store.get(group_name) or TextModelGroupNameSchema()
+    updates = request.model_dump(exclude_none=True)
+    merged = existing.model_copy(update=updates)
+    store.set(group_name, merged)
+
+    logger.info(f"Updated naming schema for group '{group_name}' (requestor={requestor.username})")
+
+    return GroupNameSchemaResponse(
+        group_name=group_name,
+        name_schema=merged,
+        is_custom=True,
+    )
+
+
+@router.delete(
+    "/text_generation/group/{group_name}/name_schema",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a custom naming schema (revert to inferred)",
+    tags=["text_utils"],
+)
+async def delete_group_name_schema(
+    group_name: str,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    apikey: Annotated[str, Depends(header_auth_scheme)],
+) -> None:
+    """Remove the persisted naming schema so the group reverts to inference."""
+    await authenticate_queue_requestor(apikey)
+    assert_primary_write_enabled(manager)
+
+    store = _require_group_schema_store(manager)
+    deleted = store.delete(group_name)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No custom naming schema found for group '{group_name}'",
+        )
+
+
+@router.put(
+    "/text_generation/{model_name:path}/name_exception",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Set or clear the naming schema exception flag on a model",
+    tags=["text_utils"],
+)
+async def set_name_exception(
+    model_name: str,
+    request: NameExceptionRequest,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    apikey: Annotated[str, Depends(header_auth_scheme)],
+) -> JSONResponse:
+    """Set or clear the ``name_schema_exception`` field on a text model.
+
+    Pass ``{"reason": "some reason"}`` to flag the model or ``{"reason": null}`` to clear.
+    Changes go through the pending queue.
+    """
+    requestor = await authenticate_queue_requestor(apikey)
+    assert_primary_write_enabled(manager)
+
+    all_models = _get_all_text_models(manager)
+    if model_name not in all_models:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Model '{model_name}' not found in text_generation category",
+        )
+
+    existing_data = dict(all_models[model_name])
+    if request.reason is not None:
+        existing_data["name_schema_exception"] = request.reason
+    else:
+        existing_data.pop("name_schema_exception", None)
+
+    queue_service = require_pending_queue_service(manager)
+    change = queue_service.enqueue_change(
+        category=_CATEGORY,
+        model_name=model_name,
+        operation=AuditOperation.UPDATE,
+        payload=existing_data,
+        requestor_id=requestor.user_id,
+        requestor_username=requestor.username,
+        notes=f"Name exception {'set' if request.reason else 'cleared'} for '{model_name}'",
+        request_metadata={"route": "set_name_exception"},
+    )
+
+    return JSONResponse(
+        status_code=status.HTTP_202_ACCEPTED,
+        content={"pending_change_id": change.change_id},
+    )
+
+
+class GroupAliasResponse(BaseModel):
+    """A single group alias entry."""
+
+    canonical: str
+    aliases: list[str]
+
+
+class GroupAliasListResponse(BaseModel):
+    """Response listing all group alias entries."""
+
+    entries: list[GroupAliasResponse]
+
+
+class SetAliasesRequest(BaseModel):
+    """Request body for setting the full alias list for a canonical group."""
+
+    aliases: list[str]
+
+
+class AddAliasRequest(BaseModel):
+    """Request body for adding a single alias to a canonical group."""
+
+    alias: str
+
+
+class RemoveAliasRequest(BaseModel):
+    """Request body for removing a single alias from a canonical group."""
+
+    alias: str
+
+
+def _require_group_alias_store(manager: ModelReferenceManager) -> GroupAliasStore:
+    """Return the group alias store or raise 503 if unavailable."""
+    store = manager.group_alias_store
+    if store is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Group alias storage is not available (backend may be in REPLICA mode).",
+        )
+    return store
+
+
+@router.get(
+    "/text_generation/aliases",
+    response_model=GroupAliasListResponse,
+    summary="List all group alias entries",
+    tags=["text_utils"],
+)
+def list_aliases(
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+) -> GroupAliasListResponse:
+    """Return all configured group alias entries."""
+    store = _require_group_alias_store(manager)
+    all_entries = store.list_all()
+    return GroupAliasListResponse(
+        entries=[
+            GroupAliasResponse(canonical=canonical, aliases=entry.aliases)
+            for canonical, entry in sorted(all_entries.items())
+        ],
+    )
+
+
+@router.get(
+    "/text_generation/aliases/{canonical}",
+    response_model=GroupAliasResponse,
+    summary="Get aliases for a canonical group",
+    tags=["text_utils"],
+)
+def get_alias(
+    canonical: str,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+) -> GroupAliasResponse:
+    """Return the alias entry for a specific canonical group name."""
+    store = _require_group_alias_store(manager)
+    entry = store.get(canonical)
+    if entry is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No alias entry for canonical group '{canonical}'",
+        )
+    return GroupAliasResponse(canonical=entry.canonical, aliases=entry.aliases)
+
+
+@router.put(
+    "/text_generation/aliases/{canonical}",
+    response_model=GroupAliasResponse,
+    summary="Set the full alias list for a canonical group",
+    tags=["text_utils"],
+)
+async def set_aliases(
+    canonical: str,
+    request: SetAliasesRequest,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    apikey: Annotated[str, Depends(header_auth_scheme)],
+) -> GroupAliasResponse:
+    """Replace all aliases for a canonical group name.
+
+    Raises 409 if any alias is already claimed by a different canonical group.
+    """
+    await authenticate_queue_requestor(apikey)
+    assert_primary_write_enabled(manager)
+
+    store = _require_group_alias_store(manager)
+    try:
+        store.set_aliases(canonical, request.aliases)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    logger.info(f"Set {len(request.aliases)} aliases for canonical group '{canonical}'")
+    return GroupAliasResponse(canonical=canonical, aliases=request.aliases)
+
+
+@router.post(
+    "/text_generation/aliases/{canonical}/add",
+    response_model=GroupAliasResponse,
+    summary="Add a single alias to a canonical group",
+    tags=["text_utils"],
+)
+async def add_alias(
+    canonical: str,
+    request: AddAliasRequest,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    apikey: Annotated[str, Depends(header_auth_scheme)],
+) -> GroupAliasResponse:
+    """Add one alias to a canonical group. Creates the entry if needed.
+
+    Raises 409 if the alias is already claimed by a different canonical group.
+    """
+    await authenticate_queue_requestor(apikey)
+    assert_primary_write_enabled(manager)
+
+    store = _require_group_alias_store(manager)
+    try:
+        store.add_alias(canonical, request.alias)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    entry = store.get(canonical)
+    assert entry is not None
+    return GroupAliasResponse(canonical=canonical, aliases=entry.aliases)
+
+
+@router.post(
+    "/text_generation/aliases/{canonical}/remove",
+    response_model=GroupAliasResponse,
+    summary="Remove a single alias from a canonical group",
+    tags=["text_utils"],
+)
+async def remove_alias(
+    canonical: str,
+    request: RemoveAliasRequest,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    apikey: Annotated[str, Depends(header_auth_scheme)],
+) -> GroupAliasResponse:
+    """Remove one alias from a canonical group.
+
+    Returns the updated entry. Raises 404 if the alias was not found.
+    """
+    await authenticate_queue_requestor(apikey)
+    assert_primary_write_enabled(manager)
+
+    store = _require_group_alias_store(manager)
+    removed = store.remove_alias(canonical, request.alias)
+    if not removed:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Alias '{request.alias}' not found under canonical group '{canonical}'",
+        )
+
+    entry = store.get(canonical)
+    if entry is None:
+        return GroupAliasResponse(canonical=canonical, aliases=[])
+    return GroupAliasResponse(canonical=canonical, aliases=entry.aliases)
+
+
+@router.delete(
+    "/text_generation/aliases/{canonical}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete all aliases for a canonical group",
+    tags=["text_utils"],
+)
+async def delete_aliases(
+    canonical: str,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    apikey: Annotated[str, Depends(header_auth_scheme)],
+) -> None:
+    """Remove the entire alias entry for a canonical group."""
+    await authenticate_queue_requestor(apikey)
+    assert_primary_write_enabled(manager)
+
+    store = _require_group_alias_store(manager)
+    deleted = store.delete(canonical)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No alias entry for canonical group '{canonical}'",
+        )
+
+
+class GroupFamilyResponse(BaseModel):
+    """A single related-group family."""
+
+    family_name: str
+    members: list[str]
+
+
+class GroupFamilyListResponse(BaseModel):
+    """Response listing all related-group families."""
+
+    families: list[GroupFamilyResponse]
+
+
+class SetFamilyRequest(BaseModel):
+    """Request body for creating or replacing a family."""
+
+    members: list[str]
+
+
+class AddFamilyMemberRequest(BaseModel):
+    """Request body for adding a single group to a family."""
+
+    group_name: str
+
+
+class RemoveFamilyMemberRequest(BaseModel):
+    """Request body for removing a single group from a family."""
+
+    group_name: str
+
+
+class DetectFamiliesResponse(BaseModel):
+    """Response from auto-detection of family suggestions."""
+
+    suggestions: list[GroupFamilyResponse]
+    total_groups_analyzed: int
+    groups_in_families: int
+    standalone_groups: int
+
+
+def _require_group_family_store(manager: ModelReferenceManager) -> GroupFamilyStore:
+    """Return the group family store or raise 503 if unavailable."""
+    store = manager.group_family_store
+    if store is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Group family storage is not available (backend may be in REPLICA mode).",
+        )
+    return store
+
+
+@router.get(
+    "/text_generation/families",
+    response_model=GroupFamilyListResponse,
+    summary="List all related-group families",
+    tags=["text_utils"],
+)
+def list_families(
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+) -> GroupFamilyListResponse:
+    """Return all configured related-group families."""
+    store = _require_group_family_store(manager)
+    all_families = store.list_all()
+    return GroupFamilyListResponse(
+        families=[
+            GroupFamilyResponse(family_name=name, members=family.members)
+            for name, family in sorted(all_families.items())
+        ],
+    )
+
+
+@router.get(
+    "/text_generation/families/detect",
+    response_model=DetectFamiliesResponse,
+    summary="Auto-detect family suggestions from current model groups",
+    tags=["text_utils"],
+)
+def detect_family_suggestions(
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    min_prefix_length: Annotated[int, Query(ge=2, le=20)] = 3,
+    min_family_size: Annotated[int, Query(ge=2, le=50)] = 2,
+) -> DetectFamiliesResponse:
+    """Run prefix-based heuristics over current group names to suggest families.
+
+    Results are suggestions only — they are not persisted automatically.
+    """
+    all_models = _get_all_text_models(manager)
+    if not all_models:
+        return DetectFamiliesResponse(
+            suggestions=[],
+            total_groups_analyzed=0,
+            groups_in_families=0,
+            standalone_groups=0,
+        )
+
+    alias_store = manager.group_alias_store
+    group_names: set[str] = set()
+    for model_name in all_models:
+        base = get_base_model_name(model_name)
+        if alias_store is not None:
+            base = alias_store.resolve(base)
+        group_names.add(base)
+
+    sorted_names = sorted(group_names)
+    suggestions = detect_families(
+        sorted_names,
+        min_prefix_length=min_prefix_length,
+        min_family_size=min_family_size,
+    )
+
+    groups_in_families = sum(len(members) for members in suggestions.values())
+
+    return DetectFamiliesResponse(
+        suggestions=[
+            GroupFamilyResponse(family_name=prefix, members=members) for prefix, members in suggestions.items()
+        ],
+        total_groups_analyzed=len(sorted_names),
+        groups_in_families=groups_in_families,
+        standalone_groups=len(sorted_names) - groups_in_families,
+    )
+
+
+@router.get(
+    "/text_generation/families/{family_name}",
+    response_model=GroupFamilyResponse,
+    summary="Get a specific related-group family",
+    tags=["text_utils"],
+)
+def get_family(
+    family_name: str,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+) -> GroupFamilyResponse:
+    """Return the family with the given name."""
+    store = _require_group_family_store(manager)
+    family = store.get_family(family_name)
+    if family is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Family '{family_name}' not found",
+        )
+    return GroupFamilyResponse(family_name=family.family_name, members=family.members)
+
+
+@router.put(
+    "/text_generation/families/{family_name}",
+    response_model=GroupFamilyResponse,
+    summary="Create or replace a related-group family",
+    tags=["text_utils"],
+)
+async def set_family(
+    family_name: str,
+    request: SetFamilyRequest,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    apikey: Annotated[str, Depends(header_auth_scheme)],
+) -> GroupFamilyResponse:
+    """Create or replace a family with the given members.
+
+    Raises 409 if any member already belongs to a different family.
+    """
+    await authenticate_queue_requestor(apikey)
+    assert_primary_write_enabled(manager)
+
+    store = _require_group_family_store(manager)
+    try:
+        store.set_family(family_name, request.members)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    logger.info(f"Set family '{family_name}' with {len(request.members)} members")
+    return GroupFamilyResponse(family_name=family_name, members=sorted(set(request.members)))
+
+
+@router.post(
+    "/text_generation/families/{family_name}/add",
+    response_model=GroupFamilyResponse,
+    summary="Add a group to a family",
+    tags=["text_utils"],
+)
+async def add_family_member(
+    family_name: str,
+    request: AddFamilyMemberRequest,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    apikey: Annotated[str, Depends(header_auth_scheme)],
+) -> GroupFamilyResponse:
+    """Add a single group to an existing family.
+
+    Raises 404 if the family does not exist, 409 if the group belongs to another family.
+    """
+    await authenticate_queue_requestor(apikey)
+    assert_primary_write_enabled(manager)
+
+    store = _require_group_family_store(manager)
+    try:
+        store.add_member(family_name, request.group_name)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    family = store.get_family(family_name)
+    assert family is not None
+    return GroupFamilyResponse(family_name=family_name, members=family.members)
+
+
+@router.post(
+    "/text_generation/families/{family_name}/remove",
+    response_model=GroupFamilyResponse,
+    summary="Remove a group from a family",
+    tags=["text_utils"],
+)
+async def remove_family_member(
+    family_name: str,
+    request: RemoveFamilyMemberRequest,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    apikey: Annotated[str, Depends(header_auth_scheme)],
+) -> GroupFamilyResponse:
+    """Remove a single group from a family.
+
+    If the family becomes empty, it is deleted entirely.
+    Raises 404 if the group was not found in the family.
+    """
+    await authenticate_queue_requestor(apikey)
+    assert_primary_write_enabled(manager)
+
+    store = _require_group_family_store(manager)
+    removed = store.remove_member(family_name, request.group_name)
+    if not removed:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Group '{request.group_name}' not found in family '{family_name}'",
+        )
+
+    family = store.get_family(family_name)
+    if family is None:
+        return GroupFamilyResponse(family_name=family_name, members=[])
+    return GroupFamilyResponse(family_name=family_name, members=family.members)
+
+
+@router.delete(
+    "/text_generation/families/{family_name}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a related-group family",
+    tags=["text_utils"],
+)
+async def delete_family(
+    family_name: str,
+    manager: Annotated[ModelReferenceManager, Depends(get_model_reference_manager)],
+    apikey: Annotated[str, Depends(header_auth_scheme)],
+) -> None:
+    """Delete an entire family, releasing all its members."""
+    await authenticate_queue_requestor(apikey)
+    assert_primary_write_enabled(manager)
+
+    store = _require_group_family_store(manager)
+    deleted = store.delete(family_name)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Family '{family_name}' not found",
+        )

--- a/src/horde_model_reference/service/v2/routers/write_validations.py
+++ b/src/horde_model_reference/service/v2/routers/write_validations.py
@@ -3,9 +3,18 @@
 from __future__ import annotations
 
 from horde_model_reference import CanonicalFormat, ModelReferenceManager
-from horde_model_reference.service.shared import assert_canonical_write_enabled
+from horde_model_reference.service.shared import assert_canonical_write_enabled, assert_primary_mode
 
 
 def assert_v2_write_enabled(manager: ModelReferenceManager) -> None:
     """Ensure writes are only attempted when canonical v2 PRIMARY backend supports them."""
     assert_canonical_write_enabled(manager, canonical_format=CanonicalFormat.v2)
+
+
+def assert_primary_write_enabled(manager: ModelReferenceManager) -> None:
+    """Ensure the backend is PRIMARY, without requiring a specific canonical format.
+
+    Use for text utility metadata operations (schemas, aliases, families) that
+    are v2-only endpoints but write to auxiliary stores, not model records.
+    """
+    assert_primary_mode(manager)

--- a/tests/service/test_text_utils.py
+++ b/tests/service/test_text_utils.py
@@ -257,3 +257,532 @@ class TestDistinctBaselines:
         assert resp.status_code == 200
         data = resp.json()
         assert data["baselines"] == ["llama3", "qwen3"]
+
+
+class TestListGroups:
+    """Tests for the group names list endpoint."""
+
+    def test_list_groups(self, api_client: TestClient, text_group_manager: ModelReferenceManager) -> None:
+        """Test listing all distinct text model group names."""
+        resp = api_client.get(f"{_V2}/text_generation/groups")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "Qwen3" in data["groups"]
+        assert "Llama-3" in data["groups"]
+
+    def test_list_groups_sorted(self, api_client: TestClient, text_group_manager: ModelReferenceManager) -> None:
+        """Test that group names are returned in sorted order."""
+        resp = api_client.get(f"{_V2}/text_generation/groups")
+        data = resp.json()
+        assert data["groups"] == sorted(data["groups"])
+
+
+class TestGroupNameSchema:
+    """Tests for group naming schema CRUD endpoints."""
+
+    def test_get_inferred_schema(self, api_client: TestClient, text_group_manager: ModelReferenceManager) -> None:
+        """Test that an inferred schema is returned when no custom schema exists."""
+        # Ensure no custom schema is persisted from other tests
+        store = text_group_manager.group_schema_store
+        if store:
+            store.delete("Qwen3")
+
+        resp = api_client.get(f"{_V2}/text_generation/group/Qwen3/name_schema")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["group_name"] == "Qwen3"
+        assert data["is_custom"] is False
+        assert data["name_schema"]["separator"] in ("-", "_")
+        assert isinstance(data["name_schema"]["part_order"], list)
+
+    def test_get_schema_group_not_found(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager
+    ) -> None:
+        """Test that requesting a schema for a non-existent group returns 404."""
+        resp = api_client.get(f"{_V2}/text_generation/group/NonExistent/name_schema")
+        assert resp.status_code == 404
+
+    def test_put_custom_schema(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """Test saving a custom naming schema for a group."""
+        resp = api_client.put(
+            f"{_V2}/text_generation/group/Qwen3/name_schema",
+            json={"separator": "_", "author_included": False},
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_custom"] is True
+        assert data["name_schema"]["separator"] == "_"
+        assert data["name_schema"]["author_included"] is False
+
+    def test_get_custom_schema_after_save(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """Test that a saved custom schema is returned on subsequent GET."""
+        # Save a custom schema
+        api_client.put(
+            f"{_V2}/text_generation/group/Qwen3/name_schema",
+            json={"separator": "_", "common_author": "Qwen"},
+            headers={"apikey": "test-key"},
+        )
+        # Retrieve it
+        resp = api_client.get(f"{_V2}/text_generation/group/Qwen3/name_schema")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_custom"] is True
+        assert data["name_schema"]["separator"] == "_"
+        assert data["name_schema"]["common_author"] == "Qwen"
+
+    def test_delete_custom_schema(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """Test deleting a custom schema reverts to inferred."""
+        # Save then delete
+        api_client.put(
+            f"{_V2}/text_generation/group/Qwen3/name_schema",
+            json={"separator": "_"},
+            headers={"apikey": "test-key"},
+        )
+        resp = api_client.delete(
+            f"{_V2}/text_generation/group/Qwen3/name_schema",
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 204
+
+        # Verify it's back to inferred
+        resp = api_client.get(f"{_V2}/text_generation/group/Qwen3/name_schema")
+        assert resp.json()["is_custom"] is False
+
+    def test_delete_nonexistent_schema(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """Test deleting a schema that doesn't exist returns 404."""
+        resp = api_client.delete(
+            f"{_V2}/text_generation/group/Qwen3/name_schema",
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 404
+
+    def test_group_response_includes_schema_custom_flag(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """Test that the group endpoint reflects custom schema state."""
+        # Before saving: inferred
+        resp = api_client.get(f"{_V2}/text_generation/group/Qwen3")
+        assert resp.json()["name_schema_is_custom"] is False
+
+        # After saving custom schema
+        api_client.put(
+            f"{_V2}/text_generation/group/Qwen3/name_schema",
+            json={"separator": "_"},
+            headers={"apikey": "test-key"},
+        )
+        resp = api_client.get(f"{_V2}/text_generation/group/Qwen3")
+        data = resp.json()
+        assert data["name_schema_is_custom"] is True
+        assert data["name_format"]["separator"] == "_"
+
+
+class TestNameException:
+    """Tests for the name_schema_exception field endpoints."""
+
+    def test_set_name_exception(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """Test setting a name exception flag on a model creates a pending change."""
+        resp = api_client.put(
+            f"{_V2}/text_generation/Qwen3-0.6B/name_exception",
+            json={"reason": "Uses non-standard naming"},
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 202
+        data = resp.json()
+        assert "pending_change_id" in data
+
+    def test_set_name_exception_model_not_found(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """Test setting exception on a non-existent model returns 404."""
+        resp = api_client.put(
+            f"{_V2}/text_generation/NonExistent/name_exception",
+            json={"reason": "test"},
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 404
+
+    def test_group_response_includes_exception_members(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager
+    ) -> None:
+        """Test that exception members appear in the group response after direct backend update."""
+        backend = text_group_manager.backend
+        all_models = backend.fetch_category(MODEL_REFERENCE_CATEGORY.text_generation)
+        record_data = dict(all_models["Qwen3-0.6B"])  # type: ignore[index]
+        record_data["name_schema_exception"] = "Historical naming"
+        backend.update_model(MODEL_REFERENCE_CATEGORY.text_generation, "Qwen3-0.6B", record_data)
+        text_group_manager._invalidate_cache()
+
+        resp = api_client.get(f"{_V2}/text_generation/group/Qwen3")
+        data = resp.json()
+        exceptions = data["exception_members"]
+        assert len(exceptions) == 1
+        assert exceptions[0]["name"] == "Qwen3-0.6B"
+        assert exceptions[0]["reason"] == "Historical naming"
+
+
+class TestParseNameExtras:
+    """Tests for extras information in the parse_name response."""
+
+    def test_parse_date_suffix_returns_extras(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager
+    ) -> None:
+        """A date suffix like 08-2024 should appear in the extras array."""
+        resp = api_client.get(
+            f"{_V2}/text_generation/parse_name",
+            params={"name": "c4ai-command-r-08-2024"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["base_name"] == "c4ai-command-r"
+        extras = data["extras"]
+        assert len(extras) >= 1
+        date_extras = [e for e in extras if e["inferred_type"] == "DATE"]
+        assert len(date_extras) == 1
+        assert date_extras[0]["value"] == "08-2024"
+
+    def test_parse_standard_name_no_extras(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager
+    ) -> None:
+        """A standard name like Qwen3-8B-Instruct should have no extras."""
+        resp = api_client.get(
+            f"{_V2}/text_generation/parse_name",
+            params={"name": "Qwen3-8B-Instruct"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["extras"] == []
+
+    def test_parse_alias_resolved_suggested_group(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager
+    ) -> None:
+        """When aliases exist, suggested_group should resolve through them."""
+        alias_store = text_group_manager.group_alias_store
+        assert alias_store is not None
+        alias_store.set_aliases("c4ai-command-r", ["c4ai-command-r-plus"])
+
+        resp = api_client.get(
+            f"{_V2}/text_generation/parse_name",
+            params={"name": "c4ai-command-r-plus-08-2024"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["suggested_group"] == "c4ai-command-r"
+
+        # Clean up
+        alias_store.delete("c4ai-command-r")
+
+
+class TestGroupAliases:
+    """Tests for group alias CRUD endpoints."""
+
+    def test_list_aliases_empty(self, api_client: TestClient, text_group_manager: ModelReferenceManager) -> None:
+        """An empty alias store should return an empty list."""
+        resp = api_client.get(f"{_V2}/text_generation/aliases")
+        assert resp.status_code == 200
+        assert resp.json()["entries"] == []
+
+    def test_set_and_list_aliases(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """Setting aliases via PUT should make them visible in the list."""
+        resp = api_client.put(
+            f"{_V2}/text_generation/aliases/c4ai-command-r",
+            json={"aliases": ["c4ai-command-r-plus", "c4ai-command-a"]},
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["canonical"] == "c4ai-command-r"
+        assert set(data["aliases"]) == {"c4ai-command-r-plus", "c4ai-command-a"}
+
+        # Verify via list endpoint
+        resp = api_client.get(f"{_V2}/text_generation/aliases")
+        entries = resp.json()["entries"]
+        assert len(entries) >= 1
+        cr_entry = [e for e in entries if e["canonical"] == "c4ai-command-r"]
+        assert len(cr_entry) == 1
+
+        # Clean up
+        api_client.delete(
+            f"{_V2}/text_generation/aliases/c4ai-command-r",
+            headers={"apikey": "test-key"},
+        )
+
+    def test_get_alias(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """GET for a specific canonical group should return its aliases."""
+        api_client.put(
+            f"{_V2}/text_generation/aliases/Broken-Tutu",
+            json={"aliases": ["Broken-Tutu-Unslop"]},
+            headers={"apikey": "test-key"},
+        )
+
+        resp = api_client.get(f"{_V2}/text_generation/aliases/Broken-Tutu")
+        assert resp.status_code == 200
+        assert resp.json()["aliases"] == ["Broken-Tutu-Unslop"]
+
+        # Clean up
+        api_client.delete(
+            f"{_V2}/text_generation/aliases/Broken-Tutu",
+            headers={"apikey": "test-key"},
+        )
+
+    def test_get_alias_not_found(self, api_client: TestClient, text_group_manager: ModelReferenceManager) -> None:
+        """GET for a non-existent canonical should return 404."""
+        resp = api_client.get(f"{_V2}/text_generation/aliases/nonexistent")
+        assert resp.status_code == 404
+
+    def test_add_single_alias(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """POST add should append a single alias to an entry."""
+        api_client.put(
+            f"{_V2}/text_generation/aliases/Broken-Tutu",
+            json={"aliases": ["Broken-Tutu-Unslop"]},
+            headers={"apikey": "test-key"},
+        )
+
+        resp = api_client.post(
+            f"{_V2}/text_generation/aliases/Broken-Tutu/add",
+            json={"alias": "Broken-Tutu-Transgression"},
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 200
+        assert "Broken-Tutu-Transgression" in resp.json()["aliases"]
+        assert "Broken-Tutu-Unslop" in resp.json()["aliases"]
+
+        # Clean up
+        api_client.delete(
+            f"{_V2}/text_generation/aliases/Broken-Tutu",
+            headers={"apikey": "test-key"},
+        )
+
+    def test_remove_single_alias(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """POST remove should remove one alias and return the updated entry."""
+        api_client.put(
+            f"{_V2}/text_generation/aliases/Broken-Tutu",
+            json={"aliases": ["alias-a", "alias-b"]},
+            headers={"apikey": "test-key"},
+        )
+
+        resp = api_client.post(
+            f"{_V2}/text_generation/aliases/Broken-Tutu/remove",
+            json={"alias": "alias-a"},
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["aliases"] == ["alias-b"]
+
+        # Clean up
+        api_client.delete(
+            f"{_V2}/text_generation/aliases/Broken-Tutu",
+            headers={"apikey": "test-key"},
+        )
+
+    def test_remove_nonexistent_alias(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """Removing a non-existent alias returns 404."""
+        api_client.put(
+            f"{_V2}/text_generation/aliases/group-x",
+            json={"aliases": ["alias-y"]},
+            headers={"apikey": "test-key"},
+        )
+
+        resp = api_client.post(
+            f"{_V2}/text_generation/aliases/group-x/remove",
+            json={"alias": "not-registered"},
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 404
+
+        # Clean up
+        api_client.delete(
+            f"{_V2}/text_generation/aliases/group-x",
+            headers={"apikey": "test-key"},
+        )
+
+    def test_delete_aliases(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """DELETE should remove the entire alias entry."""
+        api_client.put(
+            f"{_V2}/text_generation/aliases/to-delete",
+            json={"aliases": ["del-alias"]},
+            headers={"apikey": "test-key"},
+        )
+
+        resp = api_client.delete(
+            f"{_V2}/text_generation/aliases/to-delete",
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 204
+
+        resp = api_client.get(f"{_V2}/text_generation/aliases/to-delete")
+        assert resp.status_code == 404
+
+    def test_delete_nonexistent(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """Deleting a non-existent canonical returns 404."""
+        resp = api_client.delete(
+            f"{_V2}/text_generation/aliases/nope",
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 404
+
+    def test_conflict_on_duplicate_alias(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager, mock_auth_success: None
+    ) -> None:
+        """Setting an alias already claimed by another canonical returns 409."""
+        api_client.put(
+            f"{_V2}/text_generation/aliases/group-a",
+            json={"aliases": ["shared-alias"]},
+            headers={"apikey": "test-key"},
+        )
+
+        resp = api_client.put(
+            f"{_V2}/text_generation/aliases/group-b",
+            json={"aliases": ["shared-alias"]},
+            headers={"apikey": "test-key"},
+        )
+        assert resp.status_code == 409
+
+        # Clean up
+        api_client.delete(
+            f"{_V2}/text_generation/aliases/group-a",
+            headers={"apikey": "test-key"},
+        )
+
+
+class TestGroupsSummary:
+    """Tests for the enriched groups summary endpoint."""
+
+    def test_summary_returns_all_groups(
+        self, api_client: TestClient, text_group_manager: ModelReferenceManager
+    ) -> None:
+        """GET /groups/summary should return an entry for each known group."""
+        resp = api_client.get(f"{_V2}/text_generation/groups/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        group_names = [g["group_name"] for g in data["groups"]]
+        assert "Qwen3" in group_names
+        assert "Llama-3" in group_names
+        assert data["total_groups"] == len(data["groups"])
+
+    def test_summary_member_counts(self, api_client: TestClient, text_group_manager: ModelReferenceManager) -> None:
+        """Summary entries should report correct canonical and duplicate counts."""
+        resp = api_client.get(f"{_V2}/text_generation/groups/summary")
+        data = resp.json()
+        qwen = next(g for g in data["groups"] if g["group_name"] == "Qwen3")
+        assert qwen["canonical_count"] == 3
+        assert qwen["backend_duplicate_count"] == 0
+
+    def test_summary_available_sizes(self, api_client: TestClient, text_group_manager: ModelReferenceManager) -> None:
+        """Summary should include parsed sizes from model names."""
+        resp = api_client.get(f"{_V2}/text_generation/groups/summary")
+        data = resp.json()
+        qwen = next(g for g in data["groups"] if g["group_name"] == "Qwen3")
+        assert "0.6B" in qwen["available_sizes"]
+        assert "4B" in qwen["available_sizes"]
+
+    def test_summary_aggregate_totals(self, api_client: TestClient, text_group_manager: ModelReferenceManager) -> None:
+        """Aggregate fields should tally correctly."""
+        resp = api_client.get(f"{_V2}/text_generation/groups/summary")
+        data = resp.json()
+        assert data["total_models"] == sum(g["canonical_count"] + g["backend_duplicate_count"] for g in data["groups"])
+
+    def test_summary_reflects_family(
+        self,
+        api_client: TestClient,
+        text_group_manager: ModelReferenceManager,
+        mock_auth_success: None,
+    ) -> None:
+        """After creating a family, summary should report the family_name."""
+        # Create a family containing Qwen3
+        api_client.put(
+            f"{_V2}/text_generation/families/qwen-family",
+            json={"members": ["Qwen3"]},
+            headers={"apikey": "test-key"},
+        )
+
+        resp = api_client.get(f"{_V2}/text_generation/groups/summary")
+        data = resp.json()
+        qwen = next(g for g in data["groups"] if g["group_name"] == "Qwen3")
+        assert qwen["family_name"] == "qwen-family"
+        assert data["groups_with_families"] >= 1
+
+        # Clean up
+        api_client.delete(
+            f"{_V2}/text_generation/families/qwen-family",
+            headers={"apikey": "test-key"},
+        )
+
+    def test_summary_reflects_aliases(
+        self,
+        api_client: TestClient,
+        text_group_manager: ModelReferenceManager,
+        mock_auth_success: None,
+    ) -> None:
+        """After setting aliases, summary should report them."""
+        api_client.put(
+            f"{_V2}/text_generation/aliases/Qwen3",
+            json={"aliases": ["qwen-three"]},
+            headers={"apikey": "test-key"},
+        )
+
+        resp = api_client.get(f"{_V2}/text_generation/groups/summary")
+        data = resp.json()
+        qwen = next(g for g in data["groups"] if g["group_name"] == "Qwen3")
+        assert "qwen-three" in qwen["aliases"]
+        assert data["groups_with_aliases"] >= 1
+
+        # Clean up
+        api_client.delete(
+            f"{_V2}/text_generation/aliases/Qwen3",
+            headers={"apikey": "test-key"},
+        )
+
+
+class TestGroupsHealth:
+    """Tests for the group health check endpoint."""
+
+    def test_health_returns_issues(self, api_client: TestClient, text_group_manager: ModelReferenceManager) -> None:
+        """GET /groups/health should return an issue list and aggregate counts."""
+        resp = api_client.get(f"{_V2}/text_generation/groups/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "issues" in data
+        assert "total_groups_checked" in data
+        assert "groups_with_issues" in data
+        assert "issue_counts_by_type" in data
+        assert data["total_groups_checked"] >= 2
+
+    def test_singleton_group_flagged(self, api_client: TestClient, text_group_manager: ModelReferenceManager) -> None:
+        """A group with only one canonical member should have a 'singleton_group' issue."""
+        resp = api_client.get(f"{_V2}/text_generation/groups/health")
+        data = resp.json()
+        llama_issues = [i for i in data["issues"] if i["group_name"] == "Llama-3"]
+        issue_types = [i["issue_type"] for i in llama_issues]
+        assert "singleton_group" in issue_types
+
+    def test_healthy_group_no_issues(self, api_client: TestClient, text_group_manager: ModelReferenceManager) -> None:
+        """A multi-member group with consistent data should have no issues or only info-level ones."""
+        resp = api_client.get(f"{_V2}/text_generation/groups/health")
+        data = resp.json()
+        qwen_issues = [i for i in data["issues"] if i["group_name"] == "Qwen3"]
+        warning_issues = [i for i in qwen_issues if i.get("severity", "warning") == "warning"]
+        # Qwen3 has 3 consistent members — no warnings expected
+        assert len(warning_issues) == 0

--- a/tests/statistics_and_audit/test_extras_and_aliases.py
+++ b/tests/statistics_and_audit/test_extras_and_aliases.py
@@ -1,0 +1,845 @@
+"""Tests for extras extraction, group aliases, and alias-aware grouping."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from horde_model_reference.analytics.text_model_parser import (
+    ExtraPartType,
+    get_base_model_name,
+    group_text_models_by_base,
+    infer_name_format,
+    parse_text_model_name,
+)
+from horde_model_reference.group_aliases import GroupAliasStore
+from horde_model_reference.group_schema_store import GroupSchemaStore
+from horde_model_reference.model_reference_records import TextModelGroupNameSchema
+
+
+class TestExtrasExtraction:
+    """Tests for the extra-parts extraction in the parser."""
+
+    def test_date_suffix_extracted_as_extra(self) -> None:
+        """A trailing MM-YYYY date should be extracted as a DATE extra."""
+        parsed = parse_text_model_name("c4ai-command-r-08-2024")
+
+        assert parsed.base_name == "c4ai-command-r"
+        extra_types = [e.inferred_type for e in parsed.extras]
+        assert ExtraPartType.DATE in extra_types
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert date_extras[0].value == "08-2024"
+
+    def test_date_suffix_yyyy_mm(self) -> None:
+        """A trailing YYYY-MM date should also be extracted."""
+        parsed = parse_text_model_name("SomeModel-2024-08")
+
+        extra_types = [e.inferred_type for e in parsed.extras]
+        assert ExtraPartType.DATE in extra_types
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert date_extras[0].value == "2024-08"
+
+    def test_leading_version_extracted_as_extra(self) -> None:
+        """A leading dotted version (e.g. 2.0-ModelName) becomes LEADING_VERSION."""
+        parsed = parse_text_model_name("2.0-SomeModel-7B")
+
+        extra_types = [e.inferred_type for e in parsed.extras]
+        assert ExtraPartType.LEADING_VERSION in extra_types
+        version_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.LEADING_VERSION]
+        assert version_extras[0].value == "2.0"
+
+    def test_no_extras_for_standard_name(self) -> None:
+        """A standard Llama-3-8B-Instruct name should produce no extras."""
+        parsed = parse_text_model_name("Llama-3-8B-Instruct")
+
+        assert parsed.extras == []
+        assert parsed.base_name == "Llama-3"
+        assert parsed.size == "8B"
+        assert parsed.variant == "Instruct"
+
+    def test_command_r_plus_date_suffix(self) -> None:
+        """c4ai-command-r-plus-08-2024 should extract the date, leaving base intact."""
+        parsed = parse_text_model_name("c4ai-command-r-plus-08-2024")
+
+        assert "08-2024" not in parsed.base_name
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 1
+        assert date_extras[0].value == "08-2024"
+
+    def test_extras_appear_in_inferred_schema(self) -> None:
+        """infer_name_format should report extra_parts when members have extras."""
+        names = [
+            "c4ai-command-r-08-2024",
+            "c4ai-command-r-plus-08-2024",
+        ]
+        schema = infer_name_format(names)
+
+        assert ExtraPartType.DATE in schema.extra_parts
+
+    # --- 4-digit date code tests ---
+
+    def test_four_digit_yymm_date_code(self) -> None:
+        """Trailing YYMM codes like -2407 should be extracted as DATE extras."""
+        parsed = parse_text_model_name("Mistral-Large-Instruct-2407")
+
+        assert parsed.base_name == "Mistral-Large"
+        assert parsed.variant == "Instruct"
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 1
+        assert date_extras[0].value == "2407"
+
+    def test_four_digit_date_code_with_size(self) -> None:
+        """Size + 4-digit date should both be extracted, leaving a clean base."""
+        parsed = parse_text_model_name("GLM-4-32B-0414")
+
+        assert parsed.base_name == "GLM-4"
+        assert parsed.size == "32B"
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 1
+        assert date_extras[0].value == "0414"
+
+    def test_four_digit_date_code_mid_name(self) -> None:
+        """4-digit date code not at the very end should still be extracted."""
+        parsed = parse_text_model_name("GLM-4-32B-0414-abliterated")
+
+        assert parsed.base_name == "GLM-4-abliterated"
+        assert parsed.size == "32B"
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 1
+        assert date_extras[0].value == "0414"
+
+    def test_four_digit_date_code_deepseek(self) -> None:
+        """DeepSeek-V2.5-1210 should extract version and date code."""
+        parsed = parse_text_model_name("DeepSeek-V2.5-1210")
+
+        assert parsed.base_name == "DeepSeek"
+        assert parsed.version == "V2.5"
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 1
+        assert date_extras[0].value == "1210"
+
+    def test_four_digit_date_code_qwen_thinking(self) -> None:
+        """Qwen3-4B-Thinking-2507: Thinking variant + 4-digit date extracted."""
+        parsed = parse_text_model_name("Qwen3-4B-Thinking-2507")
+
+        assert parsed.base_name == "Qwen3"
+        assert parsed.size == "4B"
+        assert parsed.variant == "Thinking"
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 1
+        assert date_extras[0].value == "2507"
+
+    # --- Thinking/Reasoning variant tests ---
+
+    def test_thinking_variant_extracted(self) -> None:
+        """Thinking should be recognized as a variant."""
+        parsed = parse_text_model_name("Qwen3-30B-A3B-Thinking-2507")
+
+        assert parsed.variant == "Thinking"
+        assert "Thinking" not in parsed.base_name
+
+    def test_reasoning_variant_extracted(self) -> None:
+        """Reasoning should be recognized as a variant."""
+        parsed = parse_text_model_name("Ministral-3-14B-Reasoning-2512")
+
+        assert parsed.variant == "Reasoning"
+        assert parsed.size == "14B"
+        assert parsed.base_name == "Ministral-3"
+
+    def test_thinking_and_instruct_same_base(self) -> None:
+        """Thinking and Instruct variants of the same model should have the same base."""
+        base_instruct = get_base_model_name("Qwen3-4B-Instruct-2507")
+        base_thinking = get_base_model_name("Qwen3-4B-Thinking-2507")
+
+        assert base_instruct == base_thinking == "Qwen3"
+
+    # --- Grouping improvements with 4-digit dates ---
+
+    def test_mistral_variants_group_together(self) -> None:
+        """Mistral models with different date codes should group under same base."""
+        base_2407 = get_base_model_name("Mistral-Large-Instruct-2407")
+        base_2411 = get_base_model_name("Mistral-Large-Instruct-2411")
+
+        assert base_2407 == base_2411 == "Mistral-Large"
+
+    def test_glm_variants_group_together(self) -> None:
+        """GLM models with -0414 date code should group under GLM-4 base."""
+        base_32b = get_base_model_name("GLM-4-32B-0414")
+        base_9b = get_base_model_name("GLM-4-9B-0414")
+
+        assert base_32b == base_9b == "GLM-4"
+
+
+class TestGroupAliasStore:
+    """Tests for the group alias persistence store."""
+
+    @pytest.fixture()
+    def store_path(self, tmp_path: Path) -> Path:
+        """Return a temporary path for the alias store JSON file."""
+        return tmp_path / "aliases.json"
+
+    @pytest.fixture()
+    def store(self, store_path: Path) -> GroupAliasStore:
+        """Create a fresh GroupAliasStore backed by a temporary file."""
+        return GroupAliasStore(file_path=store_path)
+
+    def test_resolve_unknown_returns_identity(self, store: GroupAliasStore) -> None:
+        """An unknown name should resolve to itself."""
+        assert store.resolve("unknown-model") == "unknown-model"
+
+    def test_set_and_resolve(self, store: GroupAliasStore) -> None:
+        """Aliases set via set_aliases should resolve to the canonical name."""
+        store.set_aliases("c4ai-command-r", ["c4ai-command-r-plus", "c4ai-command-a"])
+
+        assert store.resolve("c4ai-command-r-plus") == "c4ai-command-r"
+        assert store.resolve("c4ai-command-a") == "c4ai-command-r"
+        assert store.resolve("c4ai-command-r") == "c4ai-command-r"
+
+    def test_add_alias(self, store: GroupAliasStore) -> None:
+        """add_alias should append to an existing canonical entry."""
+        store.set_aliases("Broken-Tutu", ["Broken-Tutu-Unslop"])
+        store.add_alias("Broken-Tutu", "Broken-Tutu-Transgression")
+
+        assert store.resolve("Broken-Tutu-Transgression") == "Broken-Tutu"
+
+    def test_remove_alias(self, store: GroupAliasStore) -> None:
+        """Removing an alias should make it resolve to itself again."""
+        store.set_aliases("base", ["alias1", "alias2"])
+        assert store.remove_alias("base", "alias1")
+        assert store.resolve("alias1") == "alias1"
+        assert store.resolve("alias2") == "base"
+
+    def test_delete_canonical(self, store: GroupAliasStore) -> None:
+        """Deleting a canonical entry should remove all its aliases."""
+        store.set_aliases("base", ["alias1"])
+        assert store.delete("base")
+        assert store.resolve("alias1") == "alias1"
+
+    def test_self_alias_raises(self, store: GroupAliasStore) -> None:
+        """A canonical name cannot be its own alias."""
+        with pytest.raises(ValueError, match="cannot be its own alias"):
+            store.set_aliases("base", ["base"])
+
+    def test_conflict_raises(self, store: GroupAliasStore) -> None:
+        """An alias already claimed by another canonical should raise."""
+        store.set_aliases("group-a", ["shared-alias"])
+        with pytest.raises(ValueError, match="already registered"):
+            store.set_aliases("group-b", ["shared-alias"])
+
+    def test_persistence_across_instances(self, store_path: Path) -> None:
+        """Data persisted by one store instance should be loaded by a new one."""
+        store1 = GroupAliasStore(file_path=store_path)
+        store1.set_aliases("canonical", ["alias-x"])
+
+        store2 = GroupAliasStore(file_path=store_path)
+        assert store2.resolve("alias-x") == "canonical"
+
+    def test_list_all(self, store: GroupAliasStore) -> None:
+        """list_all should return deep copies of all entries."""
+        store.set_aliases("g1", ["a1"])
+        store.set_aliases("g2", ["a2", "a3"])
+
+        all_entries = store.list_all()
+        assert len(all_entries) == 2
+        assert set(all_entries["g2"].aliases) == {"a2", "a3"}
+
+    def test_is_alias(self, store: GroupAliasStore) -> None:
+        """is_alias should identify registered aliases but not canonical names."""
+        store.set_aliases("canon", ["alias"])
+        assert store.is_alias("alias")
+        assert not store.is_alias("canon")
+        assert not store.is_alias("unrelated")
+
+
+class TestAliasAwareSchemaStore:
+    """Tests for alias-aware schema lookups."""
+
+    @pytest.fixture()
+    def alias_store(self, tmp_path: Path) -> GroupAliasStore:
+        """Create alias store with c4ai-command-r aliases pre-populated."""
+        store = GroupAliasStore(file_path=tmp_path / "aliases.json")
+        store.set_aliases("c4ai-command-r", ["c4ai-command-r-plus"])
+        return store
+
+    @pytest.fixture()
+    def schema_store(self, tmp_path: Path, alias_store: GroupAliasStore) -> GroupSchemaStore:
+        """Create schema store wired to the alias store."""
+        return GroupSchemaStore(file_path=tmp_path / "schemas.json", alias_store=alias_store)
+
+    def test_get_via_alias(self, schema_store: GroupSchemaStore) -> None:
+        """Looking up an alias should return the schema stored under its canonical name."""
+        schema = TextModelGroupNameSchema(separator="-", template="{base}-{size}")
+        schema_store.set("c4ai-command-r", schema)
+
+        result = schema_store.get("c4ai-command-r-plus")
+        assert result is not None
+        assert result.template == "{base}-{size}"
+
+    def test_direct_lookup_still_works(self, schema_store: GroupSchemaStore) -> None:
+        """Direct lookups by canonical name should still work."""
+        schema = TextModelGroupNameSchema(separator="-")
+        schema_store.set("direct-name", schema)
+
+        assert schema_store.get("direct-name") is not None
+
+    def test_no_alias_store_returns_none_for_alias(self, tmp_path: Path) -> None:
+        """Without an alias store, alias lookups should return None."""
+        store = GroupSchemaStore(file_path=tmp_path / "schemas.json")
+        store.set("canonical-group", TextModelGroupNameSchema())
+        assert store.get("some-alias") is None
+
+
+# ---------------------------------------------------------------------------
+# Alias-aware grouping
+# ---------------------------------------------------------------------------
+
+
+class TestAliasAwareGrouping:
+    """Tests for alias-resolved model grouping."""
+
+    @pytest.fixture()
+    def alias_store(self, tmp_path: Path) -> GroupAliasStore:
+        """Create alias store with Broken-Tutu variant aliases."""
+        store = GroupAliasStore(file_path=tmp_path / "aliases.json")
+        store.set_aliases("Broken-Tutu", ["Broken-Tutu-Unslop", "Broken-Tutu-Transgression"])
+        return store
+
+    def test_aliases_merge_groups(self, alias_store: GroupAliasStore) -> None:
+        """Aliased base names should collapse into a single group."""
+        names = [
+            "koboldcpp/Broken-Tutu-24B-Unslop-v2.0-Q4_K_M",
+            "ReadyArt/Broken-Tutu-24B-Transgression-v2.0-Q4_K_M",
+            "koboldcpp/Broken-Tutu-24B-Q5_K_M",
+        ]
+        grouped = group_text_models_by_base(names, alias_store=alias_store)
+
+        assert "Broken-Tutu" in grouped
+        assert len(grouped["Broken-Tutu"].variants) == 3
+
+    def test_no_aliases_produces_separate_groups(self) -> None:
+        """Without aliases, variant names may produce separate groups."""
+        names = [
+            "koboldcpp/Broken-Tutu-24B-Unslop-v2.0-Q4_K_M",
+            "ReadyArt/Broken-Tutu-24B-Transgression-v2.0-Q4_K_M",
+        ]
+        grouped = group_text_models_by_base(names)
+
+        # Without aliases, variant names are part of base so they may separate
+        assert len(grouped) >= 1
+
+
+class TestSchemaExtraParts:
+    """Tests for the extra_parts field on TextModelGroupNameSchema."""
+
+    def test_default_empty(self) -> None:
+        """extra_parts defaults to an empty list."""
+        schema = TextModelGroupNameSchema()
+        assert schema.extra_parts == []
+
+    def test_round_trip_serialization(self) -> None:
+        """extra_parts should survive model_dump → model_validate round-trip."""
+        schema = TextModelGroupNameSchema(extra_parts=["date", "leading_version"])
+        dumped = schema.model_dump(mode="json")
+        restored = TextModelGroupNameSchema.model_validate(dumped)
+        assert restored.extra_parts == ["date", "leading_version"]
+
+    def test_json_round_trip(self) -> None:
+        """extra_parts should survive JSON serialization round-trip."""
+        schema = TextModelGroupNameSchema(extra_parts=["date"])
+        json_str = json.dumps(schema.model_dump(mode="json"))
+        restored = TextModelGroupNameSchema.model_validate(json.loads(json_str))
+        assert restored.extra_parts == ["date"]
+
+
+# ---------------------------------------------------------------------------
+# Real-world consolidation: names that MUST resolve to the same base
+# ---------------------------------------------------------------------------
+
+
+class TestRealWorldConsolidation:
+    """Verify that real model names from the AI Horde text reference
+    correctly group together after the Phase 3 parser improvements.
+
+    Each test documents *why* the models should share a group.
+    """
+
+    def test_mistral_large_date_variants(self) -> None:
+        """Mistral-Large-Instruct-2407 / -2411 differ only by release date.
+
+        `-2407` and `-2411` are YYMM date codes (July 2024, November 2024).
+        `Instruct` is a variant keyword. Both refer to Mistral-Large at
+        different release dates, so they must share the same group.
+        """
+        base_2407 = get_base_model_name("Mistral-Large-Instruct-2407")
+        base_2411 = get_base_model_name("Mistral-Large-Instruct-2411")
+
+        assert base_2407 == "Mistral-Large"
+        assert base_2411 == "Mistral-Large"
+
+    def test_mistral_small_different_size_and_date(self) -> None:
+        """Mistral-Small-Instruct-2409 and Mistral-Small-24B-Instruct-2501.
+
+        One omits the explicit size, the other includes `24B`. Both are
+        Mistral-Small releases with different dates. The size and date
+        are stripped, leaving the same base.
+        """
+        base_no_size = get_base_model_name("Mistral-Small-Instruct-2409")
+        base_with_size = get_base_model_name("Mistral-Small-24B-Instruct-2501")
+
+        assert base_no_size == base_with_size == "Mistral-Small"
+
+    def test_glm4_multiple_sizes_same_date(self) -> None:
+        """GLM-4-32B-0414 and GLM-4-9B-0414 are size variants of GLM-4.
+
+        The `-4` in `GLM-4` is a single digit — NOT a 4-digit date code.
+        The 4-digit date pattern requires exactly 4 digits (`\\d{4}`), so
+        `-4` is safe. Only `-0414` (April 14th) is extracted as a date.
+        """
+        base_32b = get_base_model_name("GLM-4-32B-0414")
+        base_9b = get_base_model_name("GLM-4-9B-0414")
+
+        assert base_32b == base_9b == "GLM-4"
+
+    def test_glm_z1_sizes_same_date(self) -> None:
+        """GLM-Z1-32B-0414 and GLM-Z1-9B-0414 are size variants of GLM-Z1.
+
+        `Z1` is alphanumeric (starts with a letter) so won't match the
+        date pattern. The `-0414` is the only 4-digit date code present.
+        """
+        base_32b = get_base_model_name("GLM-Z1-32B-0414")
+        base_9b = get_base_model_name("GLM-Z1-9B-0414")
+
+        assert base_32b == base_9b == "GLM-Z1"
+
+    def test_qwen3_instruct_and_thinking_same_date(self) -> None:
+        """Qwen3-4B-Instruct-2507 and Qwen3-4B-Thinking-2507.
+
+        Both `Instruct` and `Thinking` are variant keywords. Both have
+        the same size (`4B`) and date code (`2507`). After stripping
+        all three, the base is `Qwen3`.
+        """
+        base_instruct = get_base_model_name("Qwen3-4B-Instruct-2507")
+        base_thinking = get_base_model_name("Qwen3-4B-Thinking-2507")
+        base_plain = get_base_model_name("Qwen3-4B")
+
+        assert base_instruct == base_thinking == base_plain == "Qwen3"
+
+    def test_ministral3_instruct_and_reasoning_multiple_sizes(self) -> None:
+        """Ministral-3-{8B,14B}-{Instruct,Reasoning}-2512 all share `Ministral-3`.
+
+        The `-3` is a single digit (not a 4-digit date). Both `Instruct`
+        and `Reasoning` are variant keywords. `8B`/`14B` are sizes.
+        `-2512` is a YYMM date. All four combinations must share a base.
+        """
+        names = [
+            "Ministral-3-8B-Instruct-2512",
+            "Ministral-3-14B-Instruct-2512",
+            "Ministral-3-8B-Reasoning-2512",
+            "Ministral-3-14B-Reasoning-2512",
+        ]
+        bases = [get_base_model_name(n) for n in names]
+        assert all(b == "Ministral-3" for b in bases)
+
+    def test_deepseek_v2_5_with_date_code(self) -> None:
+        """DeepSeek-V2.5-1210 extracts version V2.5 and date 1210.
+
+        `V2.5` matches the version pattern (`V\\d+\\.\\d+`). After version
+        removal, `-1210` is a standalone 4-digit date code (December 2010
+        or Oct 12, more likely MMDD). The base is just `DeepSeek`.
+        """
+        assert get_base_model_name("DeepSeek-V2.5-1210") == "DeepSeek"
+
+    def test_devstral_variants_with_date(self) -> None:
+        """Devstral-2-123B-Instruct-2512 and Devstral-2-123B-Instruct without date.
+
+        Both have size `123B` and variant `Instruct`. The `-2` is a single
+        digit and stays in the base. Adding date `-2512` shouldn't change the base.
+        """
+        base_with_date = get_base_model_name("Devstral-2-123B-Instruct-2512")
+        # Without a date, the base should be the same
+        base_plain = get_base_model_name("Devstral-2-123B-Instruct")
+
+        assert base_with_date == base_plain == "Devstral-2"
+
+    def test_c4ai_date_format_and_version_converge(self) -> None:
+        """c4ai-command-r-08-2024 (MM-YYYY date) and c4ai-command-r-v01 (version).
+
+        The date variant has `08-2024` extracted as a DATE extra.
+        The version variant has `v01` extracted as a version.
+        Both leave the same base: `c4ai-command-r`.
+        """
+        base_date = get_base_model_name("c4ai-command-r-08-2024")
+        base_version = get_base_model_name("c4ai-command-r-v01")
+
+        assert base_date == base_version == "c4ai-command-r"
+
+    def test_qwen3_moe_instruct_and_thinking_same_base(self) -> None:
+        """Qwen3-235B-A22B-Instruct-2507 and Qwen3-235B-A22B-Thinking-2507.
+
+        The total size `235B` is extracted. `A22B` stays in the base because
+        the lookbehind `(?<![a-zA-Z])` on the size pattern prevents matching
+        digits preceded by `A`. Both Instruct and Thinking are variants.
+        `-2507` is a date code. The base is `Qwen3-A22B`.
+        """
+        base_instruct = get_base_model_name("Qwen3-235B-A22B-Instruct-2507")
+        base_thinking = get_base_model_name("Qwen3-235B-A22B-Thinking-2507")
+        base_plain = get_base_model_name("Qwen3-235B-A22B")
+
+        assert base_instruct == base_thinking == base_plain == "Qwen3-A22B"
+
+
+# ---------------------------------------------------------------------------
+# Real-world separation: names that MUST resolve to different bases
+# ---------------------------------------------------------------------------
+
+
+class TestRealWorldSeparation:
+    """Verify that models which are genuinely distinct do NOT accidentally
+    merge into the same group.
+    """
+
+    def test_qwen3_moe_different_active_sizes(self) -> None:
+        """Qwen3-A22B vs Qwen3-A3B are architecturally distinct MoE models.
+
+        `A22B` and `A3B` represent different active parameter counts in a
+        Mixture-of-Experts architecture. They are different models, not
+        size variants. The size regex extracts the total param count (235B,
+        30B) but `A22B`/`A3B` stay in the base because of the letter
+        lookbehind guard.
+        """
+        base_a22b = get_base_model_name("Qwen3-235B-A22B")
+        base_a3b = get_base_model_name("Qwen3-30B-A3B")
+
+        assert base_a22b == "Qwen3-A22B"
+        assert base_a3b == "Qwen3-A3B"
+        assert base_a22b != base_a3b
+
+    def test_glm_z1_vs_glm_z1_rumination(self) -> None:
+        """GLM-Z1 and GLM-Z1-Rumination are different model variants.
+
+        `Rumination` is NOT in the variant keyword list (it's a unique
+        model fine-tune, not a generic deployment variant like Instruct).
+        These should remain separate groups.
+        """
+        base_plain = get_base_model_name("GLM-Z1-32B-0414")
+        base_rumination = get_base_model_name("GLM-Z1-Rumination-32B-0414")
+
+        assert base_plain == "GLM-Z1"
+        assert base_rumination == "GLM-Z1-Rumination"
+        assert base_plain != base_rumination
+
+    def test_mistral_large_vs_small_vs_nemo(self) -> None:
+        """Mistral-Large, Mistral-Small, and Mistral-Nemo are separate families.
+
+        `Large`, `Small`, and `Nemo` are integral parts of the model
+        identity, not strippable variant keywords. Only `Instruct` and
+        the date codes are removed.
+        """
+        base_large = get_base_model_name("Mistral-Large-Instruct-2407")
+        base_small = get_base_model_name("Mistral-Small-Instruct-2409")
+        base_nemo = get_base_model_name("Mistral-Nemo-Instruct-2407")
+
+        assert base_large == "Mistral-Large"
+        assert base_small == "Mistral-Small"
+        assert base_nemo == "Mistral-Nemo"
+        assert len({base_large, base_small, base_nemo}) == 3
+
+    def test_devstral_vs_devstral_small(self) -> None:
+        """Devstral-2 and Devstral-Small-2 are different model families.
+
+        `Small` here is part of the model name (not an extracted variant)
+        because the full word context makes it a model identifier.
+        """
+        base_devstral = get_base_model_name("Devstral-2-123B-Instruct-2512")
+        base_small = get_base_model_name("Devstral-Small-2-24B-Instruct-2512")
+
+        assert base_devstral == "Devstral-2"
+        assert base_small == "Devstral-Small-2"
+        assert base_devstral != base_small
+
+    def test_broken_tutu_sub_models_separate_without_aliases(self) -> None:
+        """Broken-Tutu, Broken-Tutu-Transgression, and Broken-Tutu-Unslop.
+
+        `Transgression` and `Unslop` are custom fine-tune names, not
+        recognized variant keywords. Without the alias system, these
+        correctly produce separate groups. Merging requires explicit aliases.
+        """
+        base_plain = get_base_model_name("Broken-Tutu-24B")
+        base_transgression = get_base_model_name("Broken-Tutu-24B-Transgression-v2.0")
+        base_unslop = get_base_model_name("Broken-Tutu-24B-Unslop-v2.0")
+
+        assert base_plain == "Broken-Tutu"
+        assert base_transgression == "Broken-Tutu-Transgression"
+        assert base_unslop == "Broken-Tutu-Unslop"
+        assert len({base_plain, base_transgression, base_unslop}) == 3
+
+    def test_qwen3_coder_variants_stay_separate(self) -> None:
+        """Qwen3-Coder-A35B, Qwen3-Coder-A3B, and Qwen3-Coder-Next.
+
+        Each is a distinct model within the Qwen3-Coder family. The MoE
+        active param tags (A35B, A3B) and the -Next suffix are all part
+        of the model identity.
+        """
+        base_a35b = get_base_model_name("Qwen3-Coder-480B-A35B-Instruct")
+        base_a3b = get_base_model_name("Qwen3-Coder-30B-A3B-Instruct")
+        base_next = get_base_model_name("Qwen3-Coder-Next")
+
+        assert base_a35b == "Qwen3-Coder-A35B"
+        assert base_a3b == "Qwen3-Coder-A3B"
+        assert base_next == "Qwen3-Coder-Next"
+        assert len({base_a35b, base_a3b, base_next}) == 3
+
+    def test_glm4_vs_glm4_abliterated(self) -> None:
+        """GLM-4-32B-0414 and GLM-4-32B-0414-abliterated are separate.
+
+        `abliterated` is a community modification (safety filter removal),
+        not a recognized variant keyword. The date code `0414` is extracted
+        from both, but `abliterated` stays in the base.
+        """
+        base_plain = get_base_model_name("GLM-4-32B-0414")
+        base_ablit = get_base_model_name("GLM-4-32B-0414-abliterated")
+
+        assert base_plain == "GLM-4"
+        assert base_ablit == "GLM-4-abliterated"
+        assert base_plain != base_ablit
+
+
+# ---------------------------------------------------------------------------
+# Corner cases: tricky patterns that exercise extraction boundary conditions
+# ---------------------------------------------------------------------------
+
+
+class TestParserCornerCases:
+    """Tests for edge cases and potentially ambiguous model name patterns."""
+
+    def test_single_digit_not_consumed_as_date(self) -> None:
+        """Llama-2-7B: the `-2` is a single digit, not a 4-digit date.
+
+        The 4-digit date pattern requires exactly 4 consecutive digits.
+        Single/double/triple digits in model names (Llama-2, Ministral-3,
+        GPT-4) must remain part of the base.
+        """
+        parsed = parse_text_model_name("Llama-2-7B-Instruct")
+
+        assert parsed.base_name == "Llama-2"
+        assert parsed.size == "7B"
+        assert parsed.variant == "Instruct"
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 0
+
+    def test_two_digit_not_consumed_as_date(self) -> None:
+        """Llama-3.2-3B-Instruct: the `.2` and `3` segments are not 4-digit codes.
+
+        Even though `3.2` contains digits, neither `3` nor `2` is 4 digits
+        long, so no false date extraction occurs.
+        """
+        base = get_base_model_name("Llama-3.2-3B-Instruct")
+
+        assert base == "Llama-3.2"
+
+    def test_three_digit_not_consumed_as_date(self) -> None:
+        """AID-Neo-125M: the size is 125M, and 125 is only 3 digits.
+
+        No false date extraction should occur for 3-digit numbers.
+        """
+        parsed = parse_text_model_name("AID-Neo-125M")
+
+        assert parsed.base_name == "AID-Neo"
+        assert parsed.size == "125M"
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 0
+
+    def test_five_digit_not_consumed_as_date(self) -> None:
+        """A hypothetical 5-digit suffix should NOT match the 4-digit date pattern.
+
+        The `(?![a-zA-Z0-9])` lookahead prevents matching 4 digits within
+        a longer number.
+        """
+        parsed = parse_text_model_name("SomeModel-12345-7B")
+
+        assert "12345" in parsed.base_name
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 0
+
+    def test_leading_version_with_three_segments(self) -> None:
+        """4.2.0-Broken-Tutu-24b: leading dotted version is extracted as extra.
+
+        The `4.2.0` matches `LEADING_VERSION_PATTERN` (three-segment dotted
+        version at start). After extraction, the remaining `Broken-Tutu-24b`
+        is parsed normally: size `24B` extracted, base `Broken-Tutu`.
+        """
+        parsed = parse_text_model_name("4.2.0-Broken-Tutu-24b")
+
+        assert parsed.base_name == "Broken-Tutu"
+        assert parsed.size == "24B"
+        leading = [e for e in parsed.extras if e.inferred_type == ExtraPartType.LEADING_VERSION]
+        assert len(leading) == 1
+        assert leading[0].value == "4.2.0"
+
+    def test_moe_8x7b_extracted_as_size(self) -> None:
+        """Noromaid-v0.1-mixtral-8x7b-v3: MoE size `8x7b` is extracted.
+
+        The MoE size pattern `\\d+x\\d+[BMK]` matches `8x7b`. The first
+        version pattern match is `v0.1`. After both are extracted, `v3`
+        stays in the base because only the first version is extracted.
+        """
+        parsed = parse_text_model_name("Noromaid-v0.1-mixtral-8x7b-v3")
+
+        assert parsed.size == "8X7B"
+        assert parsed.version == "v0.1"
+        # v3 remains in the base because only one version is extracted
+        assert "v3" in parsed.base_name
+
+    def test_moe_active_param_not_extracted_as_size(self) -> None:
+        """Qwen2-57B-A14B: `57B` is the size, `A14B` stays in the base.
+
+        The size regex's lookbehind `(?<![a-zA-Z])` prevents `14B` from
+        matching when preceded by the letter `A`. This preserves MoE
+        active parameter designators as part of the model identity.
+        """
+        parsed = parse_text_model_name("Qwen2-57B-A14B")
+
+        assert parsed.size == "57B"
+        assert parsed.base_name == "Qwen2-A14B"
+
+    def test_version_without_prefix_stays_in_base(self) -> None:
+        """airoboros-gpt4-1.2: unadorned `1.2` is NOT extracted as a version.
+
+        Version extraction requires a `v`/`V` prefix. Bare dotted numbers
+        stay in the base name. This is correct: airoboros-gpt4-1.2, -1.3,
+        and -1.4 are intentionally separate model releases.
+        """
+        parsed = parse_text_model_name("airoboros-33b-gpt4-1.2")
+
+        assert parsed.version is None
+        assert "1.2" in parsed.base_name
+        assert parsed.size == "33B"
+
+    def test_fractional_size_extracted(self) -> None:
+        """Qwen2.5-Coder-0.5B: the fractional size `0.5B` is extracted.
+
+        The size regex `\\d+\\.?\\d*[BMK]` matches `0.5B`. The base after
+        extraction should be `Qwen2.5-Coder`.
+        """
+        parsed = parse_text_model_name("Qwen2.5-Coder-0.5B-Instruct")
+
+        assert parsed.size == "0.5B"
+        assert parsed.variant == "Instruct"
+        assert parsed.base_name == "Qwen2.5-Coder"
+
+    def test_date_code_in_middle_with_suffix(self) -> None:
+        """GLM-4-32B-0414-abliterated: date is in the middle, suffix stays.
+
+        The 4-digit date `0414` is extracted even when followed by more
+        name segments. `-abliterated` is not a variant keyword so it
+        remains in the base: `GLM-4-abliterated`.
+        """
+        parsed = parse_text_model_name("GLM-4-32B-0414-abliterated")
+
+        assert parsed.base_name == "GLM-4-abliterated"
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 1
+        assert date_extras[0].value == "0414"
+
+    def test_underscore_separated_name(self) -> None:
+        """Pernicious_Prophecy_70B: underscore separators work like hyphens.
+
+        The size regex uses `(?<![a-zA-Z])` / `(?![a-zA-Z])` instead of
+        `\\b` specifically to handle underscore boundaries. `70B` should
+        be extracted as size.
+        """
+        parsed = parse_text_model_name("Pernicious_Prophecy_70B")
+
+        assert parsed.size == "70B"
+        assert parsed.base_name == "Pernicious_Prophecy"
+
+    def test_backend_prefix_stripped_for_grouping(self) -> None:
+        """Backend and author prefixes don't affect base name extraction.
+
+        `get_base_model_name` strips backend (koboldcpp/, aphrodite/) and
+        author (mistralai/, THUDM/) prefixes before parsing. The same model
+        registered under different backends must produce identical bases.
+        """
+        names = [
+            "aphrodite/mistralai/Mistral-Large-Instruct-2407",
+            "koboldcpp/Mistral-Large-Instruct-2407",
+            "mistralai/Mistral-Large-Instruct-2407",
+        ]
+        bases = [get_base_model_name(n) for n in names]
+
+        assert all(b == "Mistral-Large" for b in bases)
+
+    def test_multiple_extractions_all_at_once(self) -> None:
+        """Qwen3-235B-A22B-Instruct-2507 exercises every extraction stage.
+
+        - Leading version: no match (doesn't start with digits)
+        - Size: `235B` extracted
+        - Version: no v-prefix found
+        - Quant: none
+        - Variant: `Instruct` extracted
+        - Date: `2507` extracted as 4-digit code
+        - Remaining: `Qwen3-A22B`
+        """
+        parsed = parse_text_model_name("Qwen3-235B-A22B-Instruct-2507")
+
+        assert parsed.size == "235B"
+        assert parsed.variant == "Instruct"
+        assert parsed.version is None
+        assert parsed.quant is None
+        assert parsed.base_name == "Qwen3-A22B"
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 1
+        assert date_extras[0].value == "2507"
+
+    def test_mm_yyyy_takes_priority_over_four_digit(self) -> None:
+        """c4ai-command-r-08-2024: the MM-YYYY pattern matches first.
+
+        DATE_PATTERNS are checked in order. `08-2024` matches the first
+        pattern (MM-YYYY) as a single 7-character extra, rather than
+        leaving `08` behind and extracting `2024` as a standalone code.
+        """
+        parsed = parse_text_model_name("c4ai-command-r-08-2024")
+
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 1
+        assert date_extras[0].value == "08-2024"
+        assert parsed.base_name == "c4ai-command-r"
+
+    def test_code_variant_not_confused_with_model_name(self) -> None:
+        """Qwen2.5-Coder-32B-Instruct: `Code` would match as variant but
+        `Coder` does not, because the variant pattern uses word boundaries.
+
+        `\\bCode\\b` matches `Code` as a whole word. `Coder` has an `r`
+        after `Code`, so the word boundary `\\b` fails. `Coder` correctly
+        stays in the base name.
+        """
+        parsed = parse_text_model_name("Qwen2.5-Coder-32B-Instruct")
+
+        assert parsed.variant == "Instruct"
+        assert parsed.base_name == "Qwen2.5-Coder"
+        assert parsed.size == "32B"
+
+    def test_leading_size_in_name(self) -> None:
+        """13B-BlueMethod: size appears before the model name.
+
+        The size pattern has no positional constraint — it matches `13B`
+        regardless of where it appears. The base should be `BlueMethod`.
+        """
+        parsed = parse_text_model_name("13B-BlueMethod")
+
+        assert parsed.size == "13B"
+        assert parsed.base_name == "BlueMethod"
+
+    def test_version_with_many_dots(self) -> None:
+        """Captain-Eris_Violet-V0.420-12B: multi-digit version V0.420.
+
+        The version pattern matches `V\\d+(\\.\\d+)+`, so V0.420 is
+        captured as a single version string.
+        """
+        parsed = parse_text_model_name("Captain-Eris_Violet-V0.420-12B")
+
+        assert parsed.version == "V0.420"
+        assert parsed.size == "12B"
+        assert parsed.base_name == "Captain-Eris_Violet"

--- a/tests/statistics_and_audit/test_extras_and_aliases.py
+++ b/tests/statistics_and_audit/test_extras_and_aliases.py
@@ -359,11 +359,7 @@ class TestSchemaExtraParts:
 
 
 class TestRealWorldConsolidation:
-    """Verify that real model names from the AI Horde text reference
-    correctly group together after the Phase 3 parser improvements.
-
-    Each test documents *why* the models should share a group.
-    """
+    """Verify that real model names from the AI Horde text reference correctly group together."""
 
     def test_mistral_large_date_variants(self) -> None:
         """Mistral-Large-Instruct-2407 / -2411 differ only by release date.
@@ -391,7 +387,7 @@ class TestRealWorldConsolidation:
         assert base_no_size == base_with_size == "Mistral-Small"
 
     def test_glm4_multiple_sizes_same_date(self) -> None:
-        """GLM-4-32B-0414 and GLM-4-9B-0414 are size variants of GLM-4.
+        r"""GLM-4-32B-0414 and GLM-4-9B-0414 are size variants of GLM-4.
 
         The `-4` in `GLM-4` is a single digit — NOT a 4-digit date code.
         The 4-digit date pattern requires exactly 4 digits (`\\d{4}`), so
@@ -443,7 +439,7 @@ class TestRealWorldConsolidation:
         assert all(b == "Ministral-3" for b in bases)
 
     def test_deepseek_v2_5_with_date_code(self) -> None:
-        """DeepSeek-V2.5-1210 extracts version V2.5 and date 1210.
+        r"""DeepSeek-V2.5-1210 extracts version V2.5 and date 1210.
 
         `V2.5` matches the version pattern (`V\\d+\\.\\d+`). After version
         removal, `-1210` is a standalone 4-digit date code (December 2010
@@ -496,9 +492,7 @@ class TestRealWorldConsolidation:
 
 
 class TestRealWorldSeparation:
-    """Verify that models which are genuinely distinct do NOT accidentally
-    merge into the same group.
-    """
+    r"""Verify that models which are genuinely distinct do NOT accidentally merge into the same group."""
 
     def test_qwen3_moe_different_active_sizes(self) -> None:
         """Qwen3-A22B vs Qwen3-A3B are architecturally distinct MoE models.
@@ -679,7 +673,7 @@ class TestParserCornerCases:
         assert leading[0].value == "4.2.0"
 
     def test_moe_8x7b_extracted_as_size(self) -> None:
-        """Noromaid-v0.1-mixtral-8x7b-v3: MoE size `8x7b` is extracted.
+        r"""Noromaid-v0.1-mixtral-8x7b-v3: MoE size `8x7b` is extracted.
 
         The MoE size pattern `\\d+x\\d+[BMK]` matches `8x7b`. The first
         version pattern match is `v0.1`. After both are extracted, `v3`
@@ -718,7 +712,7 @@ class TestParserCornerCases:
         assert parsed.size == "33B"
 
     def test_fractional_size_extracted(self) -> None:
-        """Qwen2.5-Coder-0.5B: the fractional size `0.5B` is extracted.
+        r"""Qwen2.5-Coder-0.5B: the fractional size `0.5B` is extracted.
 
         The size regex `\\d+\\.?\\d*[BMK]` matches `0.5B`. The base after
         extraction should be `Qwen2.5-Coder`.
@@ -744,7 +738,7 @@ class TestParserCornerCases:
         assert date_extras[0].value == "0414"
 
     def test_underscore_separated_name(self) -> None:
-        """Pernicious_Prophecy_70B: underscore separators work like hyphens.
+        r"""Pernicious_Prophecy_70B: underscore separators work like hyphens.
 
         The size regex uses `(?<![a-zA-Z])` / `(?![a-zA-Z])` instead of
         `\\b` specifically to handle underscore boundaries. `70B` should
@@ -808,8 +802,7 @@ class TestParserCornerCases:
         assert parsed.base_name == "c4ai-command-r"
 
     def test_code_variant_not_confused_with_model_name(self) -> None:
-        """Qwen2.5-Coder-32B-Instruct: `Code` would match as variant but
-        `Coder` does not, because the variant pattern uses word boundaries.
+        r"""Qwen2.5-Coder-32B-Instruct: `Code` would match as variant but `Coder` does not; var. uses word boundaries.
 
         `\\bCode\\b` matches `Code` as a whole word. `Coder` has an `r`
         after `Code`, so the word boundary `\\b` fails. `Coder` correctly
@@ -833,7 +826,7 @@ class TestParserCornerCases:
         assert parsed.base_name == "BlueMethod"
 
     def test_version_with_many_dots(self) -> None:
-        """Captain-Eris_Violet-V0.420-12B: multi-digit version V0.420.
+        r"""Captain-Eris_Violet-V0.420-12B: multi-digit version V0.420.
 
         The version pattern matches `V\\d+(\\.\\d+)+`, so V0.420 is
         captured as a single version string.

--- a/tests/statistics_and_audit/test_group_families.py
+++ b/tests/statistics_and_audit/test_group_families.py
@@ -1,0 +1,368 @@
+"""Tests for related-group families: store CRUD, detection heuristics, and persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from horde_model_reference.group_families import GroupFamily, GroupFamilyStore, detect_families
+
+
+class TestGroupFamily:
+    """Tests for the GroupFamily Pydantic model."""
+
+    def test_basic_construction(self) -> None:
+        """Family should hold a name and a list of members."""
+        family = GroupFamily(family_name="Mistral", members=["Mistral-Large", "Mistral-Small"])
+        assert family.family_name == "Mistral"
+        assert family.members == ["Mistral-Large", "Mistral-Small"]
+
+    def test_empty_members_default(self) -> None:
+        """Members should default to an empty list."""
+        family = GroupFamily(family_name="Empty")
+        assert family.members == []
+
+    def test_extra_fields_forbidden(self) -> None:
+        """Extra fields not defined on the model should be rejected."""
+        with pytest.raises(Exception):
+            GroupFamily(family_name="X", members=[], unknown_field="oops")
+
+
+class TestGroupFamilyStore:
+    """Tests for GroupFamilyStore CRUD operations."""
+
+    @pytest.fixture()
+    def store_path(self, tmp_path: Path) -> Path:
+        """Return a temporary file path for the family store."""
+        return tmp_path / "families.json"
+
+    @pytest.fixture()
+    def store(self, store_path: Path) -> GroupFamilyStore:
+        """Return a fresh GroupFamilyStore instance."""
+        return GroupFamilyStore(file_path=store_path)
+
+    # -- set_family / get_family --
+
+    def test_set_and_get_family(self, store: GroupFamilyStore) -> None:
+        """Setting a family should make it retrievable by name."""
+        store.set_family("Mistral", ["Mistral-Large", "Mistral-Small", "Mistral-Nemo"])
+
+        family = store.get_family("Mistral")
+        assert family is not None
+        assert family.family_name == "Mistral"
+        assert set(family.members) == {"Mistral-Large", "Mistral-Small", "Mistral-Nemo"}
+
+    def test_get_nonexistent_family(self, store: GroupFamilyStore) -> None:
+        """Getting a family that doesn't exist should return None."""
+        assert store.get_family("Nonexistent") is None
+
+    def test_set_family_empty_members_raises(self, store: GroupFamilyStore) -> None:
+        """Setting a family with no members should raise ValueError."""
+        with pytest.raises(ValueError, match="at least one member"):
+            store.set_family("Empty", [])
+
+    def test_set_family_replaces_previous(self, store: GroupFamilyStore) -> None:
+        """Re-setting a family should replace its members."""
+        store.set_family("Llama", ["Llama-3", "Llama-3.1"])
+        store.set_family("Llama", ["Llama-3", "Llama-3.2", "Llama-3.3"])
+
+        family = store.get_family("Llama")
+        assert family is not None
+        assert "Llama-3.1" not in family.members
+        assert "Llama-3.2" in family.members
+        assert "Llama-3.3" in family.members
+
+    def test_set_family_releases_old_members(self, store: GroupFamilyStore) -> None:
+        """When a family is re-set, old members should be released from the reverse index."""
+        store.set_family("Llama", ["Llama-3", "Llama-3.1"])
+        store.set_family("Llama", ["Llama-3"])
+
+        # Llama-3.1 should now be unaffiliated
+        assert store.get_family_for_group("Llama-3.1") is None
+
+    # -- Conflict detection --
+
+    def test_member_conflict_across_families(self, store: GroupFamilyStore) -> None:
+        """A group already in one family cannot be assigned to another."""
+        store.set_family("Mistral", ["Mistral-Large", "Mistral-Small"])
+
+        with pytest.raises(ValueError, match="already belongs to family"):
+            store.set_family("OtherFamily", ["Mistral-Large", "SomeGroup"])
+
+    def test_same_member_same_family_is_fine(self, store: GroupFamilyStore) -> None:
+        """Re-assigning a member to its own family should not raise."""
+        store.set_family("Mistral", ["Mistral-Large", "Mistral-Small"])
+        store.set_family("Mistral", ["Mistral-Large", "Mistral-Small", "Mistral-Nemo"])
+
+        family = store.get_family("Mistral")
+        assert family is not None
+        assert len(family.members) == 3
+
+    # -- get_family_for_group --
+
+    def test_get_family_for_group(self, store: GroupFamilyStore) -> None:
+        """Reverse lookup: group name to its family."""
+        store.set_family("GPT-Neo", ["GPT-Neo-AID", "GPT-Neo-Picard"])
+
+        family = store.get_family_for_group("GPT-Neo-AID")
+        assert family is not None
+        assert family.family_name == "GPT-Neo"
+
+    def test_get_family_for_unaffiliated_group(self, store: GroupFamilyStore) -> None:
+        """A group with no family should return None."""
+        store.set_family("GPT-Neo", ["GPT-Neo-AID"])
+        assert store.get_family_for_group("SomeOther") is None
+
+    # -- add_member --
+
+    def test_add_member(self, store: GroupFamilyStore) -> None:
+        """Adding a member to an existing family should work."""
+        store.set_family("Mistral", ["Mistral-Large"])
+        store.add_member("Mistral", "Mistral-Small")
+
+        family = store.get_family("Mistral")
+        assert family is not None
+        assert "Mistral-Small" in family.members
+
+    def test_add_member_nonexistent_family(self, store: GroupFamilyStore) -> None:
+        """Adding to a nonexistent family should raise KeyError."""
+        with pytest.raises(KeyError, match="does not exist"):
+            store.add_member("Nonexistent", "SomeGroup")
+
+    def test_add_member_conflict(self, store: GroupFamilyStore) -> None:
+        """Adding a member that belongs to another family should raise ValueError."""
+        store.set_family("Mistral", ["Mistral-Large"])
+        store.set_family("Other", ["SomeGroup"])
+
+        with pytest.raises(ValueError, match="already belongs"):
+            store.add_member("Mistral", "SomeGroup")
+
+    def test_add_member_idempotent(self, store: GroupFamilyStore) -> None:
+        """Adding an already-present member should be a no-op."""
+        store.set_family("Mistral", ["Mistral-Large", "Mistral-Small"])
+        store.add_member("Mistral", "Mistral-Large")
+
+        family = store.get_family("Mistral")
+        assert family is not None
+        assert family.members.count("Mistral-Large") == 1
+
+    # -- remove_member --
+
+    def test_remove_member(self, store: GroupFamilyStore) -> None:
+        """Removing a member should update the family."""
+        store.set_family("Mistral", ["Mistral-Large", "Mistral-Small"])
+        removed = store.remove_member("Mistral", "Mistral-Small")
+
+        assert removed is True
+        family = store.get_family("Mistral")
+        assert family is not None
+        assert "Mistral-Small" not in family.members
+        assert store.get_family_for_group("Mistral-Small") is None
+
+    def test_remove_member_deletes_empty_family(self, store: GroupFamilyStore) -> None:
+        """Removing the last member should delete the family entirely."""
+        store.set_family("Solo", ["OnlyMember"])
+        removed = store.remove_member("Solo", "OnlyMember")
+
+        assert removed is True
+        assert store.get_family("Solo") is None
+
+    def test_remove_member_not_found(self, store: GroupFamilyStore) -> None:
+        """Removing a non-member should return False."""
+        store.set_family("Mistral", ["Mistral-Large"])
+        assert store.remove_member("Mistral", "NotHere") is False
+
+    def test_remove_member_nonexistent_family(self, store: GroupFamilyStore) -> None:
+        """Removing from a nonexistent family should return False."""
+        assert store.remove_member("Nonexistent", "SomeGroup") is False
+
+    # -- delete --
+
+    def test_delete_family(self, store: GroupFamilyStore) -> None:
+        """Deleting a family should remove it and release all members."""
+        store.set_family("Mistral", ["Mistral-Large", "Mistral-Small"])
+        deleted = store.delete("Mistral")
+
+        assert deleted is True
+        assert store.get_family("Mistral") is None
+        assert store.get_family_for_group("Mistral-Large") is None
+        assert store.get_family_for_group("Mistral-Small") is None
+
+    def test_delete_nonexistent_family(self, store: GroupFamilyStore) -> None:
+        """Deleting a nonexistent family should return False."""
+        assert store.delete("Nonexistent") is False
+
+    # -- list_all --
+
+    def test_list_all(self, store: GroupFamilyStore) -> None:
+        """list_all should return all configured families."""
+        store.set_family("Mistral", ["Mistral-Large", "Mistral-Small"])
+        store.set_family("Llama", ["Llama-3", "Llama-3.1"])
+
+        all_families = store.list_all()
+        assert len(all_families) == 2
+        assert "Mistral" in all_families
+        assert "Llama" in all_families
+
+    def test_list_all_empty(self, store: GroupFamilyStore) -> None:
+        """list_all on an empty store should return an empty dict."""
+        assert store.list_all() == {}
+
+    def test_list_all_returns_copies(self, store: GroupFamilyStore) -> None:
+        """Modifying the returned dict should not affect the store."""
+        store.set_family("Mistral", ["Mistral-Large"])
+        families = store.list_all()
+        families["Mistral"].members.append("INJECTED")
+
+        original = store.get_family("Mistral")
+        assert original is not None
+        assert "INJECTED" not in original.members
+
+    # -- Persistence --
+
+    def test_persistence_round_trip(self, store_path: Path) -> None:
+        """Data should survive a store reload from disk."""
+        store1 = GroupFamilyStore(file_path=store_path)
+        store1.set_family("Mistral", ["Mistral-Large", "Mistral-Small"])
+        store1.set_family("Llama", ["Llama-3"])
+
+        store2 = GroupFamilyStore(file_path=store_path)
+        assert store2.get_family("Mistral") is not None
+        assert store2.get_family("Llama") is not None
+        assert store2.get_family_for_group("Mistral-Large") is not None
+
+    def test_persistence_file_format(self, store_path: Path) -> None:
+        """The persisted JSON should be a dict of family_name → family data."""
+        store = GroupFamilyStore(file_path=store_path)
+        store.set_family("Mistral", ["Mistral-Large", "Mistral-Small"])
+
+        raw = json.loads(store_path.read_text(encoding="utf-8"))
+        assert "Mistral" in raw
+        assert raw["Mistral"]["family_name"] == "Mistral"
+        assert set(raw["Mistral"]["members"]) == {"Mistral-Large", "Mistral-Small"}
+
+    def test_load_nonexistent_file(self, tmp_path: Path) -> None:
+        """Loading from a nonexistent file should produce an empty store."""
+        store = GroupFamilyStore(file_path=tmp_path / "nonexistent.json")
+        assert store.list_all() == {}
+
+    def test_load_corrupt_file(self, tmp_path: Path) -> None:
+        """Loading from a corrupt file should gracefully result in an empty store."""
+        corrupt_path = tmp_path / "corrupt.json"
+        corrupt_path.write_text("not valid json{{{", encoding="utf-8")
+
+        store = GroupFamilyStore(file_path=corrupt_path)
+        assert store.list_all() == {}
+
+
+class TestDetectFamilies:
+    """Tests for the detect_families heuristic function."""
+
+    def test_basic_prefix_detection(self) -> None:
+        """Groups sharing a prefix should be detected as a family."""
+        groups = ["Mistral-Large", "Mistral-Small", "Mistral-Nemo", "Llama-3"]
+        families = detect_families(groups)
+
+        assert "Mistral" in families
+        assert set(families["Mistral"]) == {"Mistral-Large", "Mistral-Small", "Mistral-Nemo"}
+
+    def test_single_group_no_family(self) -> None:
+        """A prefix matching only one group should not form a family."""
+        groups = ["Mistral-Large", "Llama-3", "Qwen-7B"]
+        families = detect_families(groups)
+
+        assert "Mistral" not in families
+        assert "Llama" not in families
+
+    def test_empty_input(self) -> None:
+        """Empty input should produce no families."""
+        assert detect_families([]) == {}
+
+    def test_no_hyphenated_groups(self) -> None:
+        """Groups without hyphens should produce no families."""
+        groups = ["Mistral", "Llama", "Qwen"]
+        assert detect_families(groups) == {}
+
+    def test_longer_prefix_wins(self) -> None:
+        """When both 'DeepSeek' and 'DeepSeek-R1-Distill' match, the longer prefix claims its members."""
+        groups = [
+            "DeepSeek-R1-Distill-Llama",
+            "DeepSeek-R1-Distill-Qwen",
+            "DeepSeek-V2",
+            "DeepSeek-V3",
+        ]
+        families = detect_families(groups)
+
+        # DeepSeek-R1-Distill should be its own family
+        assert "DeepSeek-R1-Distill" in families
+        assert set(families["DeepSeek-R1-Distill"]) == {
+            "DeepSeek-R1-Distill-Llama",
+            "DeepSeek-R1-Distill-Qwen",
+        }
+        # DeepSeek-V2 and DeepSeek-V3 should form the broader DeepSeek family
+        assert "DeepSeek" in families
+        assert set(families["DeepSeek"]) == {"DeepSeek-V2", "DeepSeek-V3"}
+
+    def test_min_prefix_length(self) -> None:
+        """Short prefixes below min_prefix_length should be excluded."""
+        groups = ["AB-One", "AB-Two", "Long-One", "Long-Two"]
+        families = detect_families(groups, min_prefix_length=3)
+
+        assert "AB" not in families
+        assert "Long" in families
+
+    def test_min_family_size(self) -> None:
+        """Families below min_family_size should be excluded."""
+        groups = ["Mistral-Large", "Mistral-Small", "Llama-One", "Llama-Two", "Solo-Only"]
+        families = detect_families(groups, min_family_size=3)
+
+        # Mistral has only 2 members, should be excluded with min_family_size=3
+        assert "Mistral" not in families
+        assert "Llama" not in families
+
+    def test_members_are_sorted(self) -> None:
+        """Family members should be returned in sorted order."""
+        groups = ["Zeta-Two", "Zeta-One", "Zeta-Three"]
+        families = detect_families(groups)
+
+        assert families["Zeta"] == ["Zeta-One", "Zeta-Three", "Zeta-Two"]
+
+    def test_no_double_claiming(self) -> None:
+        """A group claimed by a longer prefix should not also appear in a shorter one."""
+        groups = [
+            "X-Y-A",
+            "X-Y-B",
+            "X-Z-One",
+            "X-Z-Two",
+        ]
+        families = detect_families(groups)
+
+        all_members = []
+        for members in families.values():
+            all_members.extend(members)
+        # No duplicates
+        assert len(all_members) == len(set(all_members))
+
+    def test_real_world_mistral_family(self) -> None:
+        """Realistic Mistral-like group names should form a single family."""
+        groups = [
+            "Mistral-Erebus",
+            "Mistral-Large",
+            "Mistral-Nemo",
+            "Mistral-Small",
+            "Mixtral",  # Different base — should NOT be in Mistral family
+        ]
+        families = detect_families(groups)
+
+        assert "Mistral" in families
+        assert "Mixtral" not in families.get("Mistral", [])
+
+    def test_result_keys_are_sorted(self) -> None:
+        """Result dict should have keys in sorted order."""
+        groups = ["Zeta-A", "Zeta-B", "Alpha-A", "Alpha-B"]
+        families = detect_families(groups)
+
+        keys = list(families.keys())
+        assert keys == sorted(keys)

--- a/tests/statistics_and_audit/test_group_families.py
+++ b/tests/statistics_and_audit/test_group_families.py
@@ -24,11 +24,6 @@ class TestGroupFamily:
         family = GroupFamily(family_name="Empty")
         assert family.members == []
 
-    def test_extra_fields_forbidden(self) -> None:
-        """Extra fields not defined on the model should be rejected."""
-        with pytest.raises(Exception):
-            GroupFamily(family_name="X", members=[], unknown_field="oops")
-
 
 class TestGroupFamilyStore:
     """Tests for GroupFamilyStore CRUD operations."""

--- a/tests/statistics_and_audit/test_text_model_parser.py
+++ b/tests/statistics_and_audit/test_text_model_parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from horde_model_reference.analytics.text_model_parser import (
+    ExtraPartType,
     get_base_model_name,
     get_model_size,
     get_model_variant,
@@ -214,13 +215,16 @@ class TestParseTextModelName:
         assert parsed.variant == "Instruct"
         assert parsed.version is None
 
-    def test_parse_date_code_stays_in_base(self) -> None:
-        """Test that bare date codes without v-prefix stay in the base name (Phase 1 limitation)."""
+    def test_parse_date_code_extracted_as_extra(self) -> None:
+        """Test that bare 4-digit date codes are extracted as DATE extras."""
         parsed = parse_text_model_name("Devstral-2-123B-Instruct-2512")
         assert parsed.size == "123B"
         assert parsed.variant == "Instruct"
         assert parsed.version is None
-        assert "2512" in parsed.base_name
+        assert parsed.base_name == "Devstral-2"
+        date_extras = [e for e in parsed.extras if e.inferred_type == ExtraPartType.DATE]
+        assert len(date_extras) == 1
+        assert date_extras[0].value == "2512"
 
 
 class TestGetBaseModelName:


### PR DESCRIPTION
- Introduce file-backed stores for group aliases, related-group families, and per-group naming schemas to allow admin-controlled grouping and metadata (new modules: group_aliases, group_families, group_schema_store).
- Enhance the text model parser to expose extras (ExtraNamePart/ExtraPartType), recognize date suffixes and leading version tokens, and surface extras in inferred name schemas.
- Wire alias/schema/family stores into the ModelReferenceManager and update grouping utilities to accept an alias_store so canonical names can be resolved during grouping.
- Add new TextModelGroupNameSchema and a name_schema_exception field on model records, small JSON formatting tweaks, and updated tests to cover parser/grouping behavior.